### PR TITLE
Update ordering for SQLAlchemy 2.x

### DIFF
--- a/app/services/task_core_service.py
+++ b/app/services/task_core_service.py
@@ -111,8 +111,8 @@ def get_tasks(user):
         )
         .order_by(
             UserTaskOrder.display_order.is_(None),
-            UserTaskOrder.display_order.asc().nulls_last(),
-            Task.display_order.asc().nulls_last()
+            UserTaskOrder.display_order.asc().nullslast(),
+            Task.display_order.asc().nullslast()
         )
         .all()
     )

--- a/app/services/task_export_service.py
+++ b/app/services/task_export_service.py
@@ -112,8 +112,8 @@ class TaskDataExporter:
             )
             .order_by(
                 UserTaskOrder.display_order.is_(None),
-                UserTaskOrder.display_order.asc().nulls_last(),
-                Task.display_order.asc().nulls_last()
+                UserTaskOrder.display_order.asc().nullslast(),
+                Task.display_order.asc().nullslast()
             )
             .all()
         )


### PR DESCRIPTION
## Summary
- adjust ordering API for SQLAlchemy 2.x

## Testing
- `python -m py_compile app/services/task_core_service.py app/services/task_export_service.py`
- ❌ `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6871d4ba11f0833184625b59175d0779