### PR TITLE
Add include_org flag to User.to_dict

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -108,15 +108,21 @@ class User(db.Model, UserMixin):
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
 
-    def to_dict(self):
-        return {
+    def to_dict(self, include_org=False):
+        user_dict = {
             'id': self.id,
             'wp_user_id': self.wp_user_id,
             'name': self.name,
             'email': self.email,
-            'organization_id': self.organization_id,
-            'organization_name': self.organization.name if self.organization else None
         }
+
+        if include_org:
+            user_dict.update({
+                'organization_id': self.organization_id,
+                'organization_name': self.organization.name if self.organization else None
+            })
+
+        return user_dict
 
 
 # アクセススコープ


### PR DESCRIPTION
## Summary
- add optional `include_org` flag to `User.to_dict`
- return organization details only when requested

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68726e7e0cc883319dfda9b76087bd02