### PR TITLE
Refactor soft delete handling

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -19,40 +19,18 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
 
 
 # 論理削除対応
-class SoftDeleteQuery(db.Query):
-    _with_deleted = False
-
-    def with_deleted(self):
-        self._with_deleted = True
-        return self
-
-    def __iter__(self):
-        if self._with_deleted:
-            return super().__iter__()
-        return super(SoftDeleteQuery, self.filter_by(is_deleted=False)).__iter__()
-
-    def get(self, ident):
-        entity = self._only_full_mapper_zero("get").entity
-        obj = db.session.get(entity, ident)
-        if self._with_deleted:
-            return obj
-        if obj is not None and getattr(obj, "is_deleted", False):
-            return None
-        return obj
-
-
 class SoftDeleteMixin:
+    """Mixin providing an ``is_deleted`` flag and helper methods."""
+
     is_deleted = Column(Boolean, default=False, nullable=False, server_default='0')
 
     def soft_delete(self):
+        """Mark the instance as logically deleted."""
         self.is_deleted = True
 
     def restore(self):
+        """Restore a logically deleted instance."""
         self.is_deleted = False
-
-    @declared_attr
-    def query_class(cls):
-        return SoftDeleteQuery
 
 
 # 会社

--- a/app/services/company_service.py
+++ b/app/services/company_service.py
@@ -1,10 +1,9 @@
-from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import IntegrityError
 from app.models import db, Company
 
 # Create
 def create_company(name):
-    existing = Company.query.filter_by(name=name).first()
+    existing = Company.query.filter_by(name=name, is_deleted=False).first()
     if existing:
         raise ValueError("Company with the same name already exists.")
 
@@ -20,12 +19,12 @@ def create_company(name):
 
 # Read: 全件取得（論理削除除く）
 def get_all_companies():
-    return Company.query.all()
+    return Company.query.filter_by(is_deleted=False).all()
 
 
 # Read: IDで取得（論理削除除く）
 def get_company_by_id(company_id):
-    return db.session.get(Company, company_id)
+    return Company.query.filter_by(id=company_id, is_deleted=False).first()
 
 
 # Read: 削除済も含めて取得

--- a/app/services/task_core_service.py
+++ b/app/services/task_core_service.py
@@ -4,6 +4,14 @@ from app.models import db, Task, Objective, UserTaskOrder, TaskAccessUser, TaskA
 from app.utils import check_task_access
 from sqlalchemy import and_, or_
 
+
+def get_task_by_id(task_id):
+    return Task.query.filter_by(id=task_id, is_deleted=False).first()
+
+
+def get_task_by_id_with_deleted(task_id):
+    return db.session.get(Task, task_id)
+
 def create_task(data, user):
     title = data.get('title')
     if not title:
@@ -36,7 +44,9 @@ def create_task(data, user):
     return jsonify({'message': 'タスクを追加しました', 'task_id': task.id}), 201
 
 def update_task(task_id, data, user):
-    task = Task.query.get_or_404(task_id)
+    task = get_task_by_id(task_id)
+    if not task:
+        return jsonify({'error': 'タスクが見つかりません'}), 404
     if not check_task_access(user, task, 'full'):
         return jsonify({'error': 'このタスクを編集する権限がありません'}), 403
 
@@ -58,7 +68,9 @@ def update_task(task_id, data, user):
     return jsonify({'message': 'タスクを更新しました'})
 
 def delete_task(task_id, user):
-    task = Task.query.get_or_404(task_id)
+    task = get_task_by_id(task_id)
+    if not task:
+        return jsonify({'error': 'タスクが見つかりません'}), 404
     if not check_task_access(user, task, 'full'):
         return jsonify({'error': 'このタスクを削除する権限がありません'}), 403
 


### PR DESCRIPTION
## Summary
- simplify `SoftDeleteMixin`
- use explicit `is_deleted` filtering in service functions
- rely on `Session.get()` for fetching records
- update company, task, objective and progress services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68738eed186083319143010549d4725a