### PR TITLE
Refactor access scope checks

### DIFF
--- a/app/services/objectives_service.py
+++ b/app/services/objectives_service.py
@@ -2,7 +2,7 @@
 from flask import jsonify
 from datetime import datetime
 from app.models import db, Objective, Task, Status
-from app.utils import check_access_scope
+from app.utils import check_task_access
 from app.constants import TaskAccessLevelEnum
 
 
@@ -32,7 +32,7 @@ def create_objective(data, user):
     task = get_task_by_id(task_id)
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.EDIT):
+    if not check_task_access(user, task, TaskAccessLevelEnum.EDIT):
         return {'error': 'このタスクにオブジェクティブを追加する権限がありません'}, 403
 
     due_date = None
@@ -72,7 +72,7 @@ def update_objective(objective_id, data, user):
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
 
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.EDIT):
+    if not check_task_access(user, task, TaskAccessLevelEnum.EDIT):
         return {'error': '編集権限がありません'}, 403
 
     objective.title = data.get('title', objective.title)
@@ -94,7 +94,7 @@ def get_objectives_for_task(task_id, user):
     task = get_task_by_id(task_id)
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.VIEW):
+    if not check_task_access(user, task, TaskAccessLevelEnum.VIEW):
         return {'error': '閲覧権限がありません'}, 403
 
     objectives = Objective.query.filter_by(task_id=task_id, is_deleted=False) \
@@ -121,7 +121,7 @@ def get_objective(objective_id, user):
     task = get_task_by_id(objective.task_id)
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.VIEW):
+    if not check_task_access(user, task, TaskAccessLevelEnum.VIEW):
         return {'error': '閲覧権限がありません'}, 403
 
     return {
@@ -142,7 +142,7 @@ def delete_objective(objective_id, user):
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
 
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.EDIT):
+    if not check_task_access(user, task, TaskAccessLevelEnum.EDIT):
         return {'error': '削除権限がありません'}, 403
 
     objective.soft_delete()

--- a/app/services/progress_updates_service.py
+++ b/app/services/progress_updates_service.py
@@ -1,7 +1,7 @@
 # app/services/progress_updates_service.py
 from datetime import datetime
 from app.models import db, Objective, Task, ProgressUpdate, Status, User
-from app.utils import check_access_scope
+from app.utils import check_task_access
 from app.constants import TaskAccessLevelEnum
 
 
@@ -37,7 +37,10 @@ def add_progress(objective_id, data, user):
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
 
-    if not (check_access_scope(user, task.organization_id, TaskAccessLevelEnum.EDIT) or user.id == objective.assigned_user_id):
+    if not (
+        check_task_access(user, task, TaskAccessLevelEnum.EDIT)
+        or user.id == objective.assigned_user_id
+    ):
         return {'error': '進捗追加の権限がありません'}, 403
 
     progress = ProgressUpdate(
@@ -60,7 +63,7 @@ def get_progress_list(objective_id, user):
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
 
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.VIEW):
+    if not check_task_access(user, task, TaskAccessLevelEnum.VIEW):
         return {'error': '閲覧権限がありません'}, 403
 
     progress_list = ProgressUpdate.query.filter_by(objective_id=objective_id, is_deleted=False).all()
@@ -83,7 +86,7 @@ def get_latest_progress(objective_id, user):
     if not task:
         return {'error': 'タスクが見つかりません'}, 404
 
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.VIEW):
+    if not check_task_access(user, task, TaskAccessLevelEnum.VIEW):
         return {'error': '閲覧権限がありません'}, 403
 
     progress = (
@@ -123,7 +126,7 @@ def delete_progress(progress_id, user):
     if not task or task.is_deleted:
         return {'error': 'タスクが見つかりません'}, 404
 
-    if not check_access_scope(user, task.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_task_access(user, task, TaskAccessLevelEnum.EDIT):
         return {'error': '削除権限がありません'}, 403
 
     progress.soft_delete()

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -7,9 +7,9 @@ from ..models import db, User, Organization
 from ..utils import (
     get_all_child_organizations,
     get_descendant_organizations,
-    check_access_scope,
+    check_org_access,
 )
-from ..constants import TaskAccessLevelEnum
+from ..constants import OrgRoleEnum
 
 import re
 
@@ -18,7 +18,7 @@ def is_valid_email(email):
     return re.match(r"^[\w\.-]+@[\w\.-]+\.\w+$", email)
 
 def create_user(data, current_user):
-    if not check_access_scope(current_user, data.get('organization_id'), TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, data.get('organization_id'), OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     wp_user_id = data.get('wp_user_id')
@@ -60,7 +60,7 @@ def get_user_by_id(user_id, current_user):
     if not user:
         return {'error': 'ユーザーが見つかりません'}, 404
 
-    if not check_access_scope(current_user, user.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, user.organization_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     return user.to_dict(include_org=True), 200
@@ -70,7 +70,7 @@ def update_user(user_id, data, current_user):
     if not user:
         return {'error': 'ユーザーが見つかりません'}, 404
 
-    if not check_access_scope(current_user, user.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, user.organization_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     if 'name' in data:
@@ -90,7 +90,7 @@ def delete_user(user_id, current_user):
     if not user:
         return {'error': 'ユーザーが見つかりません'}, 404
 
-    if not check_access_scope(current_user, user.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, user.organization_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     from ..models import AccessScope
@@ -109,7 +109,7 @@ def get_users(requesting_user_id, organization_id=None):
     if not requester:
         return []
 
-    if not check_access_scope(requester, organization_id or requester.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(requester, organization_id or requester.organization_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     all_orgs = Organization.query.all()
@@ -135,7 +135,7 @@ def get_user_by_email(email, current_user):
     if not user:
         return {'error': 'ユーザーが見つかりません'}, 404
 
-    if not check_access_scope(current_user, user.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, user.organization_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     return user.to_dict(include_org=True), 200
@@ -145,13 +145,13 @@ def get_user_by_wp_user_id(wp_user_id, current_user):
     if not user:
         return {'error': 'ユーザーが見つかりません'}, 404
 
-    if not check_access_scope(current_user, user.organization_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, user.organization_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     return user.to_dict(include_org=True), 200
 
 def get_users_by_org_tree(org_id, current_user):
-    if not check_access_scope(current_user, org_id, TaskAccessLevelEnum.FULL):
+    if not check_org_access(current_user, org_id, OrgRoleEnum.ORG_ADMIN):
         return {'error': '権限がありません'}, 403
 
     try:


### PR DESCRIPTION
## Summary
- switch objective and progress checks to use `check_task_access`
- fix progress/objective access by TaskAccessLevelEnum
- clean up `login_superuser` fixture usage in task core tests

## Testing
- `pytest -q` *(fails: multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876444cd56c83318b51b0259febe319