### PR TITLE
Add tests for task_order routes

### DIFF
--- a/tests/test_task_order_route.py
+++ b/tests/test_task_order_route.py
@@ -1,0 +1,72 @@
+import pytest
+import uuid
+
+@pytest.fixture(scope="function")
+def order_user(system_admin_client, root_org):
+    email = f"order_user_{uuid.uuid4()}@example.com"
+    payload = {
+        "name": "OrderUser",
+        "email": email,
+        "password": "testpass",
+        "organization_id": root_org["id"],
+        "role": "member"
+    }
+    res = system_admin_client.post("/users", json=payload)
+    assert res.status_code == 201
+    user = res.get_json()["user"]
+    user["password"] = "testpass"
+    return user
+
+@pytest.fixture(scope="function")
+def order_user_client(order_user, login_as_user):
+    return login_as_user(order_user["email"], order_user["password"])
+
+@pytest.fixture(scope="function")
+def order_user_tasks(order_user_client):
+    tasks = []
+    for i in range(3):
+        res = order_user_client.post("/tasks", json={"title": f"Order Task {i+1}"})
+        assert res.status_code == 201
+        tasks.append(res.get_json()["task"])
+    return tasks
+
+class TestTaskOrderRoutes:
+    def test_get_task_order(self, order_user_client, order_user_tasks, order_user):
+        user_id = order_user["id"]
+        res = order_user_client.get(f"/task_order/{user_id}")
+        assert res.status_code == 200
+        data = res.get_json()
+        assert isinstance(data, list)
+        assert len(data) == len(order_user_tasks)
+        expected_order = [t["id"] for t in reversed(order_user_tasks)]
+        returned_order = [item["task_id"] for item in data]
+        assert returned_order == expected_order
+
+    def test_save_task_order_and_get(self, order_user_client, order_user_tasks, order_user):
+        user_id = order_user["id"]
+        new_order = [t["id"] for t in order_user_tasks]
+        res = order_user_client.post(f"/task_order/{user_id}", json={"task_ids": new_order})
+        assert res.status_code == 200
+        assert res.get_json()["message"] == "タスクの並び順を保存しました"
+        res = order_user_client.get(f"/task_order/{user_id}")
+        assert res.status_code == 200
+        after_order = [item["task_id"] for item in res.get_json()]
+        assert after_order == new_order
+
+    def test_save_task_order_invalid(self, order_user_client, order_user):
+        user_id = order_user["id"]
+        res = order_user_client.post(f"/task_order/{user_id}", json={"task_ids": "invalid"})
+        assert res.status_code == 400
+        assert "task_ids" in res.get_json()["error"]
+
+    def test_task_order_requires_login(self, client, order_user):
+        client.post("/auth/logout")
+        res = client.get(f"/task_order/{order_user['id']}")
+        assert res.status_code == 401
+
+    def test_save_task_order_post_requires_login(self, client, order_user, order_user_tasks):
+        client.post("/auth/logout")
+        user_id = order_user["id"]
+        res = client.post(f"/task_order/{user_id}", json={"task_ids": [t["id"] for t in order_user_tasks]})
+        assert res.status_code == 401
+


### PR DESCRIPTION
## Summary
- add pytest coverage for task_order endpoints

## Testing
- `pytest -q tests/test_task_order_route.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687875ab75c08331b675dfaaa153760c