### PR TITLE
Refactor routes with Flask-Smorest

### DIFF
--- a/app/routes/access_scope_routes.py
+++ b/app/routes/access_scope_routes.py
@@ -1,21 +1,45 @@
-# app/routes/access_scope_routes.py
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
+from marshmallow import Schema, fields
 
-from flask import Blueprint, request, jsonify
 from app.services import access_scope_service
 
-access_scope_bp = Blueprint('access_scope', __name__)
+class AccessScopeSchema(Schema):
+    id = fields.Int()
+    organization_id = fields.Int()
+    role = fields.Str()
 
-@access_scope_bp.route('/users/<int:user_id>/access-scopes', methods=['GET'])
-def get_user_access_scopes(user_id):
-    result, status = access_scope_service.get_user_scopes(user_id)
-    return jsonify(result), status
+class AccessScopeInputSchema(Schema):
+    organization_id = fields.Int(required=True)
+    role = fields.Str(required=True)
 
-@access_scope_bp.route('/users/<int:user_id>/access-scopes', methods=['POST'])
-def add_access_scope(user_id):
-    result, status = access_scope_service.add_access_scope_to_user(user_id, request.json)
-    return jsonify(result), status
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
-@access_scope_bp.route('/access-scopes/<int:scope_id>', methods=['DELETE'])
-def delete_access_scope(scope_id):
-    result, status = access_scope_service.delete_access_scope(scope_id)
-    return jsonify(result), status
+access_scope_bp = Blueprint("AccessScopes", __name__, description="アクセススコープ管理")
+
+@access_scope_bp.route("/users/<int:user_id>/access-scopes")
+class UserAccessScopeResource(MethodView):
+    @access_scope_bp.response(200, AccessScopeSchema(many=True))
+    def get(self, user_id):
+        """ユーザーのスコープ一覧"""
+        result, status = access_scope_service.get_user_scopes(user_id)
+        return result, status
+
+    @access_scope_bp.arguments(AccessScopeInputSchema)
+    @access_scope_bp.response(201, MessageSchema)
+    def post(self, data, user_id):
+        """スコープ追加"""
+        result, status = access_scope_service.add_access_scope_to_user(user_id, data)
+        return result, status
+
+@access_scope_bp.route("/access-scopes/<int:scope_id>")
+class AccessScopeResource(MethodView):
+    @access_scope_bp.response(200, MessageSchema)
+    def delete(self, scope_id):
+        """スコープ削除"""
+        result, status = access_scope_service.delete_access_scope(scope_id)
+        return result, status
+

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -1,29 +1,65 @@
-# app/routes/auth_routes.py
-
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
 from flask_login import login_required
+from marshmallow import Schema, fields
+
 from app.services import auth_service
 
-auth_bp = Blueprint('auth', __name__, url_prefix='/auth')
+class LoginSchema(Schema):
+    email = fields.Str(required=True)
+    password = fields.Str(required=True)
 
-@auth_bp.route('/login', methods=['POST'])
-def login():
-    result, status = auth_service.login_with_email(request.json)
-    return jsonify(result), status
+class WPLoginSchema(Schema):
+    wp_user_id = fields.Int(required=True)
 
-@auth_bp.route('/login/by-id', methods=['POST'])
-def login_by_wp_user_id():
-    result, status = auth_service.login_with_wp_user_id(request.json)
-    return jsonify(result), status
+class UserSchema(Schema):
+    id = fields.Int()
+    wp_user_id = fields.Int(allow_none=True)
+    name = fields.Str()
+    email = fields.Str()
+    is_superuser = fields.Bool()
+    organization_id = fields.Int(allow_none=True)
+    organization_name = fields.Str(allow_none=True)
 
-@auth_bp.route('/logout', methods=['POST'])
-@login_required
-def logout():
-    result, status = auth_service.logout_user_session()
-    return jsonify(result), status
+class MessageSchema(Schema):
+    message = fields.Str()
 
-@auth_bp.route('/current_user', methods=['GET'])
-@login_required
-def get_current_user():
-    result, status = auth_service.get_current_user_info()
-    return jsonify(result), status
+auth_bp = Blueprint("Auth", __name__, url_prefix="/auth", description="認証")
+
+@auth_bp.route("/login")
+class LoginResource(MethodView):
+    @auth_bp.arguments(LoginSchema)
+    @auth_bp.response(200, UserSchema)
+    def post(self, data):
+        """メールでログイン"""
+        result, status = auth_service.login_with_email(data)
+        return result, status
+
+@auth_bp.route("/login/by-id")
+class LoginByIDResource(MethodView):
+    @auth_bp.arguments(WPLoginSchema)
+    @auth_bp.response(200, UserSchema)
+    def post(self, data):
+        """WP IDでログイン"""
+        result, status = auth_service.login_with_wp_user_id(data)
+        return result, status
+
+@auth_bp.route("/logout")
+class LogoutResource(MethodView):
+    @login_required
+    @auth_bp.response(200, MessageSchema)
+    def post(self):
+        """ログアウト"""
+        result, status = auth_service.logout_user_session()
+        return result, status
+
+@auth_bp.route("/current_user")
+class CurrentUserResource(MethodView):
+    @login_required
+    @auth_bp.response(200, UserSchema)
+    def get(self):
+        """現在のユーザー取得"""
+        result, status = auth_service.get_current_user_info()
+        return result, status
+

--- a/app/routes/company_routes.py
+++ b/app/routes/company_routes.py
@@ -1,104 +1,119 @@
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request, jsonify, send_file
+from flask_login import login_required, current_user
+from marshmallow import Schema, fields
+
 from app.services import company_service
-from flask_login import current_user, login_required
 from app.utils import require_superuser
 
-company_bp = Blueprint('company', __name__, url_prefix='/companies')
+class CompanySchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
 
+class CompanyInputSchema(Schema):
+    name = fields.Str(required=True)
 
-# 会社一覧（論理削除除く）
-@company_bp.route('', methods=['GET'])
-@login_required
-def list_companies():
-    require_superuser(current_user)
-    companies = company_service.get_all_companies()
-    return jsonify([c.to_dict() for c in companies])
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
+company_bp = Blueprint("Companies", __name__, url_prefix="/companies", description="会社管理")
 
-# 会社の詳細（論理削除除く）
-@company_bp.route('/<int:company_id>', methods=['GET'])
-@login_required
-def get_company_by_id(company_id):
-    require_superuser(current_user)
-    company = company_service.get_company_by_id(company_id)
-    if not company:
-        return jsonify({'error': 'Company not found'}), 404
-    return jsonify(company.to_dict())
+@company_bp.route("")
+class CompanyListResource(MethodView):
+    @login_required
+    @company_bp.response(200, CompanySchema(many=True))
+    def get(self):
+        """会社一覧取得"""
+        require_superuser(current_user)
+        companies = company_service.get_all_companies()
+        return [c.to_dict() for c in companies]
 
+    @login_required
+    @company_bp.arguments(CompanyInputSchema)
+    @company_bp.response(201, CompanySchema)
+    def post(self, data):
+        """会社作成"""
+        require_superuser(current_user)
+        try:
+            company = company_service.create_company(data.get("name"))
+            return company.to_dict(), 201
+        except ValueError as e:
+            return {"error": str(e)}, 400
 
-# 会社の詳細（削除済も含む）
-@company_bp.route('/with_deleted/<int:company_id>', methods=['GET'])
-@login_required
-def get_company_by_id_with_deleted(company_id):
-    require_superuser(current_user)
-    company = company_service.get_company_by_id_with_deleted(company_id)
-    if not company:
-        return jsonify({'error': 'Company not found'}), 404
-    return jsonify(company.to_dict())
-
-
-# 会社作成
-@company_bp.route('', methods=['POST'])
-@login_required
-def create_company():
-    require_superuser(current_user)
-    data = request.get_json()
-    name = data.get('name')
-    if not name:
-        return jsonify({'error': 'Company name is required'}), 400
-    try:
-        company = company_service.create_company(name)
-        return jsonify(company.to_dict()), 201
-    except ValueError as e:
-        return jsonify({'error': str(e)}), 400
-
-
-# 会社名の更新
-@company_bp.route('/<int:company_id>', methods=['PUT'])
-@login_required
-def update_company(company_id):
-    require_superuser(current_user)
-    data = request.get_json()
-    new_name = data.get('name')
-    if not new_name:
-        return jsonify({'error': 'New name is required'}), 400
-    try:
-        company = company_service.update_company(company_id, new_name)
+@company_bp.route("/<int:company_id>")
+class CompanyResource(MethodView):
+    @login_required
+    @company_bp.response(200, CompanySchema)
+    def get(self, company_id):
+        """会社詳細取得"""
+        require_superuser(current_user)
+        company = company_service.get_company_by_id(company_id)
         if not company:
-            return jsonify({'error': 'Company not found'}), 404
-        return jsonify(company.to_dict())
-    except ValueError as e:
-        return jsonify({'error': str(e)}), 400
+            return {"error": "Company not found"}, 404
+        return company.to_dict()
 
+    @login_required
+    @company_bp.arguments(CompanyInputSchema)
+    @company_bp.response(200, CompanySchema)
+    def put(self, data, company_id):
+        """会社更新"""
+        require_superuser(current_user)
+        new_name = data.get("name")
+        if not new_name:
+            return {"error": "New name is required"}, 400
+        try:
+            company = company_service.update_company(company_id, new_name)
+            if not company:
+                return {"error": "Company not found"}, 404
+            return company.to_dict()
+        except ValueError as e:
+            return {"error": str(e)}, 400
 
-# 論理削除
-@company_bp.route('/<int:company_id>', methods=['DELETE'])
-@login_required
-def delete_company(company_id):
-    require_superuser(current_user)
-    success = company_service.delete_company(company_id)
-    if not success:
-        return jsonify({'error': 'Company not found'}), 404
-    return jsonify({'message': 'Company deleted (soft)'})
+    @login_required
+    @company_bp.response(200, MessageSchema)
+    def delete(self, company_id):
+        """会社の論理削除"""
+        require_superuser(current_user)
+        success = company_service.delete_company(company_id)
+        if not success:
+            return {"error": "Company not found"}, 404
+        return {"message": "Company deleted (soft)"}
 
+@company_bp.route("/with_deleted/<int:company_id>")
+class CompanyWithDeletedResource(MethodView):
+    @login_required
+    @company_bp.response(200, CompanySchema)
+    def get(self, company_id):
+        """削除済み含む会社詳細取得"""
+        require_superuser(current_user)
+        company = company_service.get_company_by_id_with_deleted(company_id)
+        if not company:
+            return {"error": "Company not found"}, 404
+        return company.to_dict()
 
-# 復元
-@company_bp.route('/restore/<int:company_id>', methods=['POST'])
-@login_required
-def restore_company(company_id):
-    require_superuser(current_user)
-    success = company_service.restore_company(company_id)
-    if not success:
-        return jsonify({'error': 'Company not found'}), 404
-    return jsonify({'message': 'Company restored'})
+@company_bp.route("/restore/<int:company_id>")
+class CompanyRestoreResource(MethodView):
+    @login_required
+    @company_bp.response(200, MessageSchema)
+    def post(self, company_id):
+        """会社復元"""
+        require_superuser(current_user)
+        success = company_service.restore_company(company_id)
+        if not success:
+            return {"error": "Company not found"}, 404
+        return {"message": "Company restored"}
 
+@company_bp.route("/permanent/<int:company_id>")
+class CompanyPermanentDeleteResource(MethodView):
+    @login_required
+    @company_bp.response(200, MessageSchema)
+    def delete(self, company_id):
+        """会社物理削除"""
+        require_superuser(current_user)
+        success = company_service.delete_company_permanently(company_id)
+        if not success:
+            return {"error": "Company not found or cannot be deleted"}, 404
+        return {"message": "Company permanently deleted"}
 
-# 物理削除（必要な場合のみ）
-@company_bp.route('/permanent/<int:company_id>', methods=['DELETE'])
-@login_required
-def delete_company_permanently(company_id):
-    require_superuser(current_user)
-    success = company_service.delete_company_permanently(company_id)
-    if not success:
-        return jsonify({'error': 'Company not found or cannot be deleted'}), 404
-    return jsonify({'message': 'Company permanently deleted'})

--- a/app/routes/objectives_route.py
+++ b/app/routes/objectives_route.py
@@ -1,46 +1,86 @@
-# app/routes/objectives_route.py
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
 from flask_login import login_required, current_user
+from marshmallow import Schema, fields
+
 from app.services import objectives_service
 
-objectives_bp = Blueprint('objectives', __name__)
+class ObjectiveSchema(Schema):
+    id = fields.Int()
+    task_id = fields.Int()
+    title = fields.Str()
+    due_date = fields.Str(allow_none=True)
+    assigned_user_id = fields.Int(allow_none=True)
+    status_id = fields.Int()
+    created_by = fields.Int()
+    created_at = fields.Str()
 
-@objectives_bp.route('/objectives', methods=['POST'])
-@login_required
-def create_objective():
-    result, status = objectives_service.create_objective(request.json, current_user)
-    return jsonify(result), status
+class ObjectiveInputSchema(Schema):
+    task_id = fields.Int(required=True)
+    title = fields.Str(required=True)
+    due_date = fields.Str(load_default=None)
+    assigned_user_id = fields.Int(load_default=None)
+    status_id = fields.Int(load_default=None)
 
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
-@objectives_bp.route('/objectives/<int:objective_id>', methods=['PUT'])
-@login_required
-def update_objective(objective_id):
-    result, status = objectives_service.update_objective(objective_id, request.json, current_user)
-    return jsonify(result), status
+class StatusSchema(Schema):
+    id = fields.Int()
+    label = fields.Str()
 
+objectives_bp = Blueprint("Objectives", __name__, description="オブジェクティブ管理")
 
-@objectives_bp.route('/tasks/<int:task_id>/objectives', methods=['GET'])
-@login_required
-def get_objectives_for_task(task_id):
-    result, status = objectives_service.get_objectives_for_task(task_id, current_user)
-    return jsonify(result), status
+@objectives_bp.route('/objectives')
+class ObjectiveListResource(MethodView):
+    @login_required
+    @objectives_bp.arguments(ObjectiveInputSchema)
+    @objectives_bp.response(201, MessageSchema)
+    def post(self, data):
+        """オブジェクティブ作成"""
+        result, status = objectives_service.create_objective(data, current_user)
+        return result, status
 
+@objectives_bp.route('/objectives/<int:objective_id>')
+class ObjectiveResource(MethodView):
+    @login_required
+    @objectives_bp.arguments(ObjectiveInputSchema)
+    @objectives_bp.response(200, MessageSchema)
+    def put(self, data, objective_id):
+        """オブジェクティブ更新"""
+        result, status = objectives_service.update_objective(objective_id, data, current_user)
+        return result, status
 
-@objectives_bp.route('/objectives/<int:objective_id>', methods=['GET'])
-@login_required
-def get_objective(objective_id):
-    result, status = objectives_service.get_objective(objective_id, current_user)
-    return jsonify(result), status
+    @login_required
+    @objectives_bp.response(200, MessageSchema)
+    def delete(self, objective_id):
+        """オブジェクティブ削除"""
+        result, status = objectives_service.delete_objective(objective_id, current_user)
+        return result, status
 
+    @login_required
+    @objectives_bp.response(200, ObjectiveSchema)
+    def get(self, objective_id):
+        """オブジェクティブ詳細取得"""
+        result, status = objectives_service.get_objective(objective_id, current_user)
+        return result, status
 
-@objectives_bp.route('/objectives/<int:objective_id>', methods=['DELETE'])
-@login_required
-def delete_objective(objective_id):
-    result, status = objectives_service.delete_objective(objective_id, current_user)
-    return jsonify(result), status
+@objectives_bp.route('/tasks/<int:task_id>/objectives')
+class TaskObjectivesResource(MethodView):
+    @login_required
+    @objectives_bp.response(200, fields.Dict())
+    def get(self, task_id):
+        """タスクのオブジェクティブ一覧"""
+        result, status = objectives_service.get_objectives_for_task(task_id, current_user)
+        return result, status
 
+@objectives_bp.route('/statuses')
+class StatusListResource(MethodView):
+    @objectives_bp.response(200, StatusSchema(many=True))
+    def get(self):
+        """ステータス一覧"""
+        result = objectives_service.get_statuses()
+        return result
 
-@objectives_bp.route('/statuses', methods=['GET'])
-def get_statuses():
-    result = objectives_service.get_statuses()
-    return jsonify(result)

--- a/app/routes/organization_routes.py
+++ b/app/routes/organization_routes.py
@@ -1,9 +1,34 @@
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
 from flask_login import login_required, current_user
-from app.models import Organization
+from marshmallow import Schema, fields
+
 from app.services import organization_service
 
-organization_bp = Blueprint('organization', __name__, url_prefix='/organizations')
+organization_bp = Blueprint("Organizations", __name__, url_prefix="/organizations", description="組織管理")
+
+class OrganizationSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+    org_code = fields.Str()
+    company_id = fields.Int()
+    parent_id = fields.Int(allow_none=True)
+    level = fields.Int()
+
+class OrganizationInputSchema(Schema):
+    name = fields.Str(required=True)
+    org_code = fields.Str(required=True)
+    company_id = fields.Int(load_default=None)
+    parent_id = fields.Int(load_default=None)
+
+class OrganizationUpdateSchema(Schema):
+    name = fields.Str()
+    parent_id = fields.Int(allow_none=True)
+
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
 
 def resolve_company_id(provided_company_id):
@@ -13,96 +38,97 @@ def resolve_company_id(provided_company_id):
         raise ValueError("company_id が指定されていないか、ユーザーに紐づく組織がありません。")
     return current_user.organization.company_id
 
+@organization_bp.route("")
+class OrganizationListResource(MethodView):
+    @login_required
+    @organization_bp.arguments(OrganizationInputSchema)
+    @organization_bp.response(201, OrganizationSchema)
+    def post(self, data):
+        """組織作成"""
+        name = data.get("name")
+        org_code = data.get("org_code")
+        company_id = data.get("company_id")
+        parent_id = data.get("parent_id")
+        if not name or not org_code:
+            return {"error": "name と org_code は必須です"}, 400
+        try:
+            resolved_company_id = resolve_company_id(company_id)
+            if parent_id is None:
+                if not organization_service.can_create_root_organization(resolved_company_id):
+                    return {"error": "この会社にはすでにルート組織が存在します"}, 400
+            org = organization_service.create_organization(name, org_code, resolved_company_id, parent_id)
+            return org.to_dict(), 201
+        except ValueError as e:
+            return {"error": str(e)}, 400
 
-@organization_bp.route('', methods=['POST'])
-@login_required
-def create_organization():
-    data = request.get_json()
-    name = data.get('name')
-    org_code = data.get('org_code')
-    company_id = data.get('company_id')
-    parent_id = data.get('parent_id')
+    @login_required
+    @organization_bp.response(200, OrganizationSchema(many=True))
+    def get(self):
+        """組織一覧取得"""
+        company_id = request.args.get("company_id", type=int)
+        try:
+            resolved_company_id = resolve_company_id(company_id)
+            orgs = organization_service.get_organizations(resolved_company_id)
+            return [org.to_dict() for org in orgs]
+        except ValueError as e:
+            return {"error": str(e)}, 400
 
-    if not name or not org_code:
-        return jsonify({'error': 'name と org_code は必須です'}), 400
-
-    try:
-        resolved_company_id = resolve_company_id(company_id)
-
-        if parent_id is None:
-            if not organization_service.can_create_root_organization(resolved_company_id):
-                return jsonify({'error': 'この会社にはすでにルート組織が存在します'}), 400
-
-        org = organization_service.create_organization(name, org_code, resolved_company_id, parent_id)
-        return jsonify(org.to_dict()), 201
-    except ValueError as e:
-        return jsonify({'error': str(e)}), 400
-
-
-@organization_bp.route('/', methods=['GET'])
-@login_required
-def get_organizations():
-    company_id = request.args.get('company_id', type=int)
-    try:
-        resolved_company_id = resolve_company_id(company_id)
-        orgs = organization_service.get_organizations(resolved_company_id)
-        return jsonify([org.to_dict() for org in orgs])
-    except ValueError as e:
-        return jsonify({'error': str(e)}), 400
-
-
-@organization_bp.route('/<int:org_id>', methods=['GET'])
-@login_required
-def get_organization_by_id(org_id):
-    org = organization_service.get_organization_by_id(org_id)
-    if not org:
-        return jsonify({'error': '組織が見つかりません'}), 404
-    return jsonify(org.to_dict())
-
-
-@organization_bp.route('/<int:org_id>', methods=['PUT'])
-@login_required
-def update_organization(org_id):
-    data = request.get_json()
-    name = data.get('name')
-    parent_id = data.get('parent_id')
-
-    try:
-        org = organization_service.update_organization(org_id, name, parent_id)
+@organization_bp.route("/<int:org_id>")
+class OrganizationResource(MethodView):
+    @login_required
+    @organization_bp.response(200, OrganizationSchema)
+    def get(self, org_id):
+        """組織取得"""
+        org = organization_service.get_organization_by_id(org_id)
         if not org:
-            return jsonify({'error': '組織が見つかりません'}), 404
-        return jsonify(org.to_dict())
-    except ValueError as e:
-        return jsonify({'error': str(e)}), 400
+            return {"error": "組織が見つかりません"}, 404
+        return org.to_dict()
 
+    @login_required
+    @organization_bp.arguments(OrganizationUpdateSchema)
+    @organization_bp.response(200, OrganizationSchema)
+    def put(self, data, org_id):
+        """組織更新"""
+        try:
+            org = organization_service.update_organization(org_id, data.get("name"), data.get("parent_id"))
+            if not org:
+                return {"error": "組織が見つかりません"}, 404
+            return org.to_dict()
+        except ValueError as e:
+            return {"error": str(e)}, 400
 
-@organization_bp.route('/<int:org_id>', methods=['DELETE'])
-@login_required
-def delete_organization(org_id):
-    success, message = organization_service.delete_organization(org_id)
-    if not success:
-        return jsonify({'error': message}), 400
-    return jsonify({'message': message})
+    @login_required
+    @organization_bp.response(200, MessageSchema)
+    def delete(self, org_id):
+        """組織削除"""
+        success, message = organization_service.delete_organization(org_id)
+        if not success:
+            return {"error": message}, 400
+        return {"message": message}
 
+@organization_bp.route("/tree")
+class OrganizationTreeResource(MethodView):
+    @login_required
+    @organization_bp.response(200, fields.List(fields.Nested(OrganizationSchema)))
+    def get(self):
+        """組織ツリー取得"""
+        company_id = request.args.get("company_id", type=int)
+        try:
+            resolved_company_id = resolve_company_id(company_id)
+            tree = organization_service.get_organization_tree(resolved_company_id)
+            return tree
+        except ValueError as e:
+            return {"error": str(e)}, 400
 
-@organization_bp.route('/tree', methods=['GET'])
-@login_required
-def get_organization_tree():
-    company_id = request.args.get('company_id', type=int)
-    try:
-        resolved_company_id = resolve_company_id(company_id)
-        tree = organization_service.get_organization_tree(resolved_company_id)
-        return jsonify(tree)
-    except ValueError as e:
-        return jsonify({'error': str(e)}), 400
+@organization_bp.route("/children")
+class OrganizationChildrenResource(MethodView):
+    @login_required
+    @organization_bp.response(200, OrganizationSchema(many=True))
+    def get(self):
+        """子組織取得"""
+        parent_id = request.args.get("parent_id", type=int)
+        if parent_id is None:
+            return {"error": "parent_id パラメータが必要です"}, 400
+        children = organization_service.get_children(parent_id)
+        return [org.to_dict() for org in children]
 
-
-@organization_bp.route('/children', methods=['GET'])
-@login_required
-def get_children():
-    parent_id = request.args.get('parent_id', type=int)
-    if parent_id is None:
-        return jsonify({'error': 'parent_id パラメータが必要です'}), 400
-
-    children = organization_service.get_children(parent_id)
-    return jsonify([org.to_dict() for org in children])

--- a/app/routes/progress_updates_route.py
+++ b/app/routes/progress_updates_route.py
@@ -1,34 +1,61 @@
-# app/routes/progress_updates_route.py
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
 from flask_login import login_required, current_user
+from marshmallow import Schema, fields
+
 from app.services import progress_updates_service
 
-progress_bp = Blueprint('progress_updates', __name__)
+class ProgressInputSchema(Schema):
+    status_id = fields.Int(required=True)
+    detail = fields.Str(required=True)
+    report_date = fields.Str(required=True)
 
+class ProgressSchema(Schema):
+    id = fields.Int()
+    status = fields.Str()
+    detail = fields.Str()
+    report_date = fields.Str()
+    updated_by = fields.Str()
 
-@progress_bp.route('/objectives/<int:objective_id>/progress', methods=['POST'])
-@login_required
-def add_progress(objective_id):
-    result, status = progress_updates_service.add_progress(objective_id, request.json, current_user)
-    return jsonify(result), status
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
+progress_bp = Blueprint("Progress", __name__, description="進捗更新")
 
-@progress_bp.route('/objectives/<int:objective_id>/progress', methods=['GET'])
-@login_required
-def get_progress(objective_id):
-    result, status = progress_updates_service.get_progress_list(objective_id, current_user)
-    return jsonify(result), status
+@progress_bp.route("/objectives/<int:objective_id>/progress")
+class ProgressListResource(MethodView):
+    @login_required
+    @progress_bp.arguments(ProgressInputSchema)
+    @progress_bp.response(201, MessageSchema)
+    def post(self, data, objective_id):
+        """進捗追加"""
+        result, status = progress_updates_service.add_progress(objective_id, data, current_user)
+        return result, status
 
+    @login_required
+    @progress_bp.response(200, ProgressSchema(many=True))
+    def get(self, objective_id):
+        """進捗一覧取得"""
+        result, status = progress_updates_service.get_progress_list(objective_id, current_user)
+        return result, status
 
-@progress_bp.route('/objectives/<int:objective_id>/latest-progress', methods=['GET'])
-@login_required
-def get_latest_progress(objective_id):
-    result, status = progress_updates_service.get_latest_progress(objective_id, current_user)
-    return jsonify(result), status
+@progress_bp.route("/objectives/<int:objective_id>/latest-progress")
+class LatestProgressResource(MethodView):
+    @login_required
+    @progress_bp.response(200, ProgressSchema)
+    def get(self, objective_id):
+        """最新進捗取得"""
+        result, status = progress_updates_service.get_latest_progress(objective_id, current_user)
+        return result, status
 
+@progress_bp.route("/progress/<int:progress_id>")
+class ProgressResource(MethodView):
+    @login_required
+    @progress_bp.response(200, MessageSchema)
+    def delete(self, progress_id):
+        """進捗削除"""
+        result, status = progress_updates_service.delete_progress(progress_id, current_user)
+        return result, status
 
-@progress_bp.route('/progress/<int:progress_id>', methods=['DELETE'])
-@login_required
-def delete_progress(progress_id):
-    result, status = progress_updates_service.delete_progress(progress_id, current_user)
-    return jsonify(result), status

--- a/app/routes/task_access_route.py
+++ b/app/routes/task_access_route.py
@@ -1,25 +1,67 @@
-from flask import Blueprint, request, jsonify
-from flask_login import current_user, login_required
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
+from flask_login import login_required, current_user
+from marshmallow import Schema, fields
+
 from app.services import task_access_service
 
-task_access_bp = Blueprint('task_access', __name__, url_prefix='/tasks/<int:task_id>/scope')
+class AccessUserSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+    email = fields.Str()
+    access_level = fields.Str()
 
-@task_access_bp.route('/access_levels', methods=['PUT'])
-@login_required
-def update_access_level(task_id):
-    return task_access_service.update_access_level(task_id, request.json, current_user)
+class OrgAccessSchema(Schema):
+    organization_id = fields.Int()
+    name = fields.Str()
+    access_level = fields.Str()
 
-@task_access_bp.route('/users', methods=['GET'])
-@login_required
-def get_task_users(task_id):
-    return task_access_service.get_task_users(task_id)
+class AccessLevelInputSchema(Schema):
+    user_access = fields.List(fields.Dict(), required=True)
+    organization_access = fields.List(fields.Dict(), required=True)
 
-@task_access_bp.route('/access_users', methods=['GET'])
-@login_required
-def get_task_access_users(task_id):
-    return task_access_service.get_task_access_users(task_id)
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
-@task_access_bp.route('/access_organizations', methods=['GET'])
-@login_required
-def get_task_access_organizations(task_id):
-    return task_access_service.get_task_access_organizations(task_id)
+task_access_bp = Blueprint("TaskAccess", __name__, url_prefix="/tasks/<int:task_id>/scope", description="タスクアクセス")
+
+@task_access_bp.route('/access_levels')
+class AccessLevelResource(MethodView):
+    @login_required
+    @task_access_bp.arguments(AccessLevelInputSchema)
+    @task_access_bp.response(200, MessageSchema)
+    def put(self, data, task_id):
+        """アクセスレベル更新"""
+        resp = task_access_service.update_access_level(task_id, data, current_user)
+        data, status = resp.get_json(), resp.status_code
+        return data, status
+
+@task_access_bp.route('/users')
+class TaskUsersResource(MethodView):
+    @login_required
+    @task_access_bp.response(200, AccessUserSchema(many=True))
+    def get(self, task_id):
+        """タスクユーザー取得"""
+        resp = task_access_service.get_task_users(task_id)
+        return resp.get_json(), resp.status_code
+
+@task_access_bp.route('/access_users')
+class TaskAccessUsersResource(MethodView):
+    @login_required
+    @task_access_bp.response(200, AccessUserSchema(many=True))
+    def get(self, task_id):
+        """ユーザーアクセス一覧"""
+        resp = task_access_service.get_task_access_users(task_id)
+        return resp.get_json(), resp.status_code
+
+@task_access_bp.route('/access_organizations')
+class TaskAccessOrganizationsResource(MethodView):
+    @login_required
+    @task_access_bp.response(200, OrgAccessSchema(many=True))
+    def get(self, task_id):
+        """組織アクセス一覧"""
+        resp = task_access_service.get_task_access_organizations(task_id)
+        return resp.get_json(), resp.status_code
+

--- a/app/routes/task_core_route.py
+++ b/app/routes/task_core_route.py
@@ -1,30 +1,82 @@
-from flask import Blueprint, request, jsonify
-from flask_login import current_user, login_required
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
+from flask_login import login_required, current_user
+from marshmallow import Schema, fields
+
 from app.services import task_core_service
 
-task_core_bp = Blueprint('task_core', __name__, url_prefix='/tasks')
+class TaskSchema(Schema):
+    id = fields.Int()
+    status_id = fields.Int(allow_none=True)
+    title = fields.Str()
+    description = fields.Str()
+    due_date = fields.Str(allow_none=True)
+    assigned_user_id = fields.Int(allow_none=True)
+    created_by = fields.Int()
+    created_at = fields.Str()
+    display_order = fields.Int(allow_none=True)
+    organization_id = fields.Int()
 
-@task_core_bp.route('', methods=['POST'])
-@login_required
-def create_task():
-    return task_core_service.create_task(request.json, current_user)
+class TaskInputSchema(Schema):
+    title = fields.Str(required=True)
+    description = fields.Str(load_default="")
+    due_date = fields.Str(load_default=None)
+    status_id = fields.Int(load_default=None)
+    display_order = fields.Int(load_default=None)
 
-@task_core_bp.route('/<int:task_id>', methods=['PUT'])
-@login_required
-def update_task(task_id):
-    return task_core_service.update_task(task_id, request.json, current_user)
+class OrderSchema(Schema):
+    order = fields.List(fields.Int(), required=True)
 
-@task_core_bp.route('/<int:task_id>', methods=['DELETE'])
-@login_required
-def delete_task(task_id):
-    return task_core_service.delete_task(task_id, current_user)
+class MessageSchema(Schema):
+    message = fields.Str()
+    error = fields.Str(load_default=None)
 
-@task_core_bp.route('', methods=['GET'])
-@login_required
-def get_tasks():
-    return task_core_service.get_tasks(current_user)
+task_core_bp = Blueprint("Tasks", __name__, url_prefix="/tasks", description="タスク管理")
 
-@task_core_bp.route('/<int:task_id>/objectives/order', methods=['POST'])
-@login_required
-def update_objective_order(task_id):
-    return task_core_service.update_objective_order(task_id, request.json)
+@task_core_bp.route("")
+class TaskListResource(MethodView):
+    @login_required
+    @task_core_bp.arguments(TaskInputSchema)
+    @task_core_bp.response(201, MessageSchema)
+    def post(self, data):
+        """タスク作成"""
+        resp, status = task_core_service.create_task(data, current_user)
+        return resp.get_json(), status
+
+    @login_required
+    @task_core_bp.response(200, fields.Dict())
+    def get(self):
+        """タスク一覧"""
+        resp, status = task_core_service.get_tasks(current_user)
+        if isinstance(resp, dict):
+            return resp, status
+        return resp.get_json(), status
+
+@task_core_bp.route("/<int:task_id>")
+class TaskResource(MethodView):
+    @login_required
+    @task_core_bp.arguments(TaskInputSchema)
+    @task_core_bp.response(200, MessageSchema)
+    def put(self, data, task_id):
+        """タスク更新"""
+        resp, status = task_core_service.update_task(task_id, data, current_user)
+        return resp.get_json(), status
+
+    @login_required
+    @task_core_bp.response(200, MessageSchema)
+    def delete(self, task_id):
+        """タスク削除"""
+        resp, status = task_core_service.delete_task(task_id, current_user)
+        return resp.get_json(), status
+
+@task_core_bp.route("/<int:task_id>/objectives/order")
+class ObjectiveOrderResource(MethodView):
+    @login_required
+    @task_core_bp.arguments(OrderSchema)
+    @task_core_bp.response(200, MessageSchema)
+    def post(self, data, task_id):
+        """オブジェクティブ順序更新"""
+        resp, status = task_core_service.update_objective_order(task_id, data)
+        return resp.get_json(), status
+

--- a/app/routes/task_order_route.py
+++ b/app/routes/task_order_route.py
@@ -1,15 +1,38 @@
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
 from flask_login import login_required
+from marshmallow import Schema, fields
+
 from app.services import task_order_service
 
-task_order_bp = Blueprint('task_order', __name__, url_prefix='/task_order')
+class TaskOrderSchema(Schema):
+    task_id = fields.Int()
+    title = fields.Str()
 
-@task_order_bp.route('/<int:user_id>', methods=['GET'])
-@login_required
-def get_task_order(user_id):
-    return task_order_service.get_task_order(user_id)
+class TaskOrderInputSchema(Schema):
+    task_ids = fields.List(fields.Int(), required=True)
 
-@task_order_bp.route('/<int:user_id>', methods=['POST'])
-@login_required
-def save_task_order(user_id):
-    return task_order_service.save_task_order(user_id, request.json)
+class MessageSchema(Schema):
+    message = fields.Str()
+
+
+task_order_bp = Blueprint("TaskOrder", __name__, url_prefix="/task_order", description="タスク並び順")
+
+@task_order_bp.route('/<int:user_id>')
+class TaskOrderResource(MethodView):
+    @login_required
+    @task_order_bp.response(200, TaskOrderSchema(many=True))
+    def get(self, user_id):
+        """タスク並び順取得"""
+        resp = task_order_service.get_task_order(user_id)
+        return resp.get_json(), resp.status_code
+
+    @login_required
+    @task_order_bp.arguments(TaskOrderInputSchema)
+    @task_order_bp.response(200, MessageSchema)
+    def post(self, data, user_id):
+        """タスク並び順保存"""
+        resp = task_order_service.save_task_order(user_id, data)
+        return resp.get_json(), resp.status_code
+

--- a/app/routes/test_routes.py
+++ b/app/routes/test_routes.py
@@ -1,7 +1,15 @@
-from flask import Blueprint, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from marshmallow import Schema, fields
 
-test_bp = Blueprint('test', __name__)
+class MessageSchema(Schema):
+    message = fields.Str()
 
-@test_bp.route('/ping', methods=['GET'])
-def ping():
-    return jsonify({"message": "pong"}), 200
+test_bp = Blueprint('Test', __name__, description="テスト用エンドポイント")
+
+@test_bp.route('/ping')
+class PingResource(MethodView):
+    @test_bp.response(200, MessageSchema)
+    def get(self):
+        """動作確認用"""
+        return {"message": "pong"}

--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -1,59 +1,104 @@
-# routes/user_routes.py
-
-from flask import Blueprint, request, jsonify
+from flask_smorest import Blueprint
+from flask.views import MethodView
+from flask import request
 from flask_login import login_required, current_user
+from marshmallow import Schema, fields
+
 from app.services import user_service
 
-user_bp = Blueprint('user', __name__)
+class UserSchema(Schema):
+    id = fields.Int()
+    wp_user_id = fields.Int(allow_none=True)
+    name = fields.Str()
+    email = fields.Str()
+    is_superuser = fields.Bool()
+    organization_id = fields.Int(allow_none=True)
+    organization_name = fields.Str(allow_none=True)
 
-@user_bp.route('/users', methods=['POST'])
-@login_required
-def create_user():
-    result, status = user_service.create_user(request.json, current_user)
-    return jsonify(result), status
+class UserInputSchema(Schema):
+    wp_user_id = fields.Int(load_default=None)
+    name = fields.Str(required=True)
+    email = fields.Str(required=True)
+    password = fields.Str(load_default=None)
+    role = fields.Str(load_default=None)
+    organization_id = fields.Int(required=True)
 
-@user_bp.route('/users/<int:user_id>', methods=['GET'])
-@login_required
-def get_user(user_id):
-    result, status = user_service.get_user_by_id(user_id, current_user)
-    return jsonify(result), status
+class MessageSchema(Schema):
+    message = fields.Str()
 
-@user_bp.route('/users/<int:user_id>', methods=['PUT'])
-@login_required
-def update_user(user_id):
-    result, status = user_service.update_user(user_id, request.json, current_user)
-    return jsonify(result), status
+user_bp = Blueprint("Users", __name__, description="ユーザー管理")
 
-@user_bp.route('/users/<int:user_id>', methods=['DELETE'])
-@login_required
-def delete_user(user_id):
-    result, status = user_service.delete_user(user_id, current_user)
-    return jsonify(result), status
+@user_bp.route("/users")
+class UsersResource(MethodView):
+    @login_required
+    @user_bp.arguments(UserInputSchema)
+    @user_bp.response(201, MessageSchema)
+    def post(self, data):
+        """ユーザー作成"""
+        result, status = user_service.create_user(data, current_user)
+        if isinstance(result, dict) and status:
+            return result, status
+        return result
 
-@user_bp.route('/users', methods=['GET'])
-@login_required
-def get_users():
-    user_id = request.args.get('user_id', type=int)
-    org_id = request.args.get('organization_id', type=int)
-    result, status = user_service.get_users(user_id, org_id)
-    return jsonify(result), status
+    @login_required
+    @user_bp.response(200, UserSchema(many=True))
+    def get(self):
+        """ユーザー一覧取得"""
+        user_id = request.args.get("user_id", type=int)
+        org_id = request.args.get("organization_id", type=int)
+        result, status = user_service.get_users(user_id, org_id)
+        return result, status
 
-@user_bp.route('/users/by-email', methods=['GET'])
-@login_required
-def get_user_by_email():
-    email = request.args.get('email')
-    result, status = user_service.get_user_by_email(email, current_user)
-    return jsonify(result), status
+@user_bp.route("/users/<int:user_id>")
+class UserResource(MethodView):
+    @login_required
+    @user_bp.response(200, UserSchema)
+    def get(self, user_id):
+        """ユーザー取得"""
+        result, status = user_service.get_user_by_id(user_id, current_user)
+        return result, status
 
-@user_bp.route('/users/id-lookup', methods=['GET'])
-@login_required
-def get_user_by_wp_user_id():
-    wp_user_id = request.args.get('wp_user_id', type=int)
-    result, status = user_service.get_user_by_wp_user_id(wp_user_id, current_user)
-    return jsonify(result), status
+    @login_required
+    @user_bp.arguments(UserInputSchema)
+    @user_bp.response(200, UserSchema)
+    def put(self, data, user_id):
+        """ユーザー更新"""
+        result, status = user_service.update_user(user_id, data, current_user)
+        return result, status
 
-@user_bp.route('/users/by-org-tree/<int:org_id>', methods=['GET'])
-@login_required
-def get_users_by_org_tree(org_id):
-    result, status = user_service.get_users_by_org_tree(org_id, current_user)
-    return jsonify(result), status
+    @login_required
+    @user_bp.response(200, MessageSchema)
+    def delete(self, user_id):
+        """ユーザー削除"""
+        result, status = user_service.delete_user(user_id, current_user)
+        return result, status
+
+@user_bp.route("/users/by-email")
+class UserByEmailResource(MethodView):
+    @login_required
+    @user_bp.response(200, UserSchema)
+    def get(self):
+        """メールアドレスでユーザー取得"""
+        email = request.args.get("email")
+        result, status = user_service.get_user_by_email(email, current_user)
+        return result, status
+
+@user_bp.route("/users/id-lookup")
+class UserByWPIDResource(MethodView):
+    @login_required
+    @user_bp.response(200, UserSchema)
+    def get(self):
+        """WordPress IDでユーザー取得"""
+        wp_user_id = request.args.get("wp_user_id", type=int)
+        result, status = user_service.get_user_by_wp_user_id(wp_user_id, current_user)
+        return result, status
+
+@user_bp.route("/users/by-org-tree/<int:org_id>")
+class UsersByOrgTreeResource(MethodView):
+    @login_required
+    @user_bp.response(200, UserSchema(many=True))
+    def get(self, org_id):
+        """組織ツリーでユーザー一覧取得"""
+        result, status = user_service.get_users_by_org_tree(org_id, current_user)
+        return result, status
+


### PR DESCRIPTION
## Summary
- migrate all route modules to use `flask_smorest.Blueprint`
- implement `MethodView` classes per endpoint
- add marshmallow schemas for request and response bodies

## Testing
- `pytest -q` *(fails: 47 failed, 12 passed, 2 warnings, 57 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68796090468483318d6b941f76272865