### PR TITLE
Refactor schemas and unify API responses

### DIFF
--- a/app/routes/access_scope_routes.py
+++ b/app/routes/access_scope_routes.py
@@ -1,28 +1,20 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
-from marshmallow import Schema, fields
-
 from app.services import access_scope_service
-
-class AccessScopeSchema(Schema):
-    id = fields.Int()
-    organization_id = fields.Int()
-    role = fields.Str()
-
-class AccessScopeInputSchema(Schema):
-    organization_id = fields.Int(required=True)
-    role = fields.Str(required=True)
-
-class MessageSchema(Schema):
-    message = fields.Str()
-    error = fields.Str(load_default=None)
+from app.schemas import (
+    AccessScopeSchema,
+    AccessScopeInputSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 access_scope_bp = Blueprint("AccessScopes", __name__, description="アクセススコープ管理")
 
 @access_scope_bp.route("/users/<int:user_id>/access-scopes")
 class UserAccessScopeResource(MethodView):
     @access_scope_bp.response(200, AccessScopeSchema(many=True))
+    @access_scope_bp.response(404, ErrorResponseSchema)
     def get(self, user_id):
         """ユーザーのスコープ一覧"""
         result, status = access_scope_service.get_user_scopes(user_id)
@@ -30,6 +22,9 @@ class UserAccessScopeResource(MethodView):
 
     @access_scope_bp.arguments(AccessScopeInputSchema)
     @access_scope_bp.response(201, MessageSchema)
+    @access_scope_bp.response(200, MessageSchema)
+    @access_scope_bp.response(400, ErrorResponseSchema)
+    @access_scope_bp.response(404, ErrorResponseSchema)
     def post(self, data, user_id):
         """スコープ追加"""
         result, status = access_scope_service.add_access_scope_to_user(user_id, data)
@@ -38,6 +33,7 @@ class UserAccessScopeResource(MethodView):
 @access_scope_bp.route("/access-scopes/<int:scope_id>")
 class AccessScopeResource(MethodView):
     @access_scope_bp.response(200, MessageSchema)
+    @access_scope_bp.response(404, ErrorResponseSchema)
     def delete(self, scope_id):
         """スコープ削除"""
         result, status = access_scope_service.delete_access_scope(scope_id)

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -2,35 +2,25 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required
-from marshmallow import Schema, fields
-
 from app.services import auth_service
-
-class LoginSchema(Schema):
-    email = fields.Str(required=True)
-    password = fields.Str(required=True)
-
-class WPLoginSchema(Schema):
-    wp_user_id = fields.Int(required=True)
-
-class UserSchema(Schema):
-    id = fields.Int()
-    wp_user_id = fields.Int(allow_none=True)
-    name = fields.Str()
-    email = fields.Str()
-    is_superuser = fields.Bool()
-    organization_id = fields.Int(allow_none=True)
-    organization_name = fields.Str(allow_none=True)
-
-class MessageSchema(Schema):
-    message = fields.Str()
+from app.schemas import (
+    LoginSchema,
+    WPLoginSchema,
+    UserSchema,
+    UserCreateResponseSchema,
+    LoginResponseSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 auth_bp = Blueprint("Auth", __name__, url_prefix="/auth", description="認証")
 
 @auth_bp.route("/login")
 class LoginResource(MethodView):
     @auth_bp.arguments(LoginSchema)
-    @auth_bp.response(200, UserSchema)
+    @auth_bp.response(200, LoginResponseSchema)
+    @auth_bp.response(400, ErrorResponseSchema)
+    @auth_bp.response(401, ErrorResponseSchema)
     def post(self, data):
         """メールでログイン"""
         result, status = auth_service.login_with_email(data)
@@ -39,7 +29,9 @@ class LoginResource(MethodView):
 @auth_bp.route("/login/by-id")
 class LoginByIDResource(MethodView):
     @auth_bp.arguments(WPLoginSchema)
-    @auth_bp.response(200, UserSchema)
+    @auth_bp.response(200, LoginResponseSchema)
+    @auth_bp.response(400, ErrorResponseSchema)
+    @auth_bp.response(404, ErrorResponseSchema)
     def post(self, data):
         """WP IDでログイン"""
         result, status = auth_service.login_with_wp_user_id(data)
@@ -49,6 +41,7 @@ class LoginByIDResource(MethodView):
 class LogoutResource(MethodView):
     @login_required
     @auth_bp.response(200, MessageSchema)
+    @auth_bp.response(401, ErrorResponseSchema)
     def post(self):
         """ログアウト"""
         result, status = auth_service.logout_user_session()
@@ -58,6 +51,7 @@ class LogoutResource(MethodView):
 class CurrentUserResource(MethodView):
     @login_required
     @auth_bp.response(200, UserSchema)
+    @auth_bp.response(401, ErrorResponseSchema)
     def get(self):
         """現在のユーザー取得"""
         result, status = auth_service.get_current_user_info()

--- a/app/routes/company_routes.py
+++ b/app/routes/company_routes.py
@@ -2,21 +2,15 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request, jsonify, send_file
 from flask_login import login_required, current_user
-from marshmallow import Schema, fields
 
 from app.services import company_service
 from app.utils import require_superuser
-
-class CompanySchema(Schema):
-    id = fields.Int()
-    name = fields.Str()
-
-class CompanyInputSchema(Schema):
-    name = fields.Str(required=True)
-
-class MessageSchema(Schema):
-    message = fields.Str()
-    error = fields.Str(load_default=None)
+from app.schemas import (
+    CompanySchema,
+    CompanyInputSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 company_bp = Blueprint("Companies", __name__, url_prefix="/companies", description="会社管理")
 
@@ -24,6 +18,7 @@ company_bp = Blueprint("Companies", __name__, url_prefix="/companies", descripti
 class CompanyListResource(MethodView):
     @login_required
     @company_bp.response(200, CompanySchema(many=True))
+    @company_bp.response(403, ErrorResponseSchema)
     def get(self):
         """会社一覧取得"""
         require_superuser(current_user)
@@ -33,6 +28,8 @@ class CompanyListResource(MethodView):
     @login_required
     @company_bp.arguments(CompanyInputSchema)
     @company_bp.response(201, CompanySchema)
+    @company_bp.response(400, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def post(self, data):
         """会社作成"""
         require_superuser(current_user)
@@ -46,6 +43,8 @@ class CompanyListResource(MethodView):
 class CompanyResource(MethodView):
     @login_required
     @company_bp.response(200, CompanySchema)
+    @company_bp.response(404, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def get(self, company_id):
         """会社詳細取得"""
         require_superuser(current_user)
@@ -57,6 +56,9 @@ class CompanyResource(MethodView):
     @login_required
     @company_bp.arguments(CompanyInputSchema)
     @company_bp.response(200, CompanySchema)
+    @company_bp.response(400, ErrorResponseSchema)
+    @company_bp.response(404, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def put(self, data, company_id):
         """会社更新"""
         require_superuser(current_user)
@@ -73,6 +75,8 @@ class CompanyResource(MethodView):
 
     @login_required
     @company_bp.response(200, MessageSchema)
+    @company_bp.response(404, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def delete(self, company_id):
         """会社の論理削除"""
         require_superuser(current_user)
@@ -85,6 +89,8 @@ class CompanyResource(MethodView):
 class CompanyWithDeletedResource(MethodView):
     @login_required
     @company_bp.response(200, CompanySchema)
+    @company_bp.response(404, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def get(self, company_id):
         """削除済み含む会社詳細取得"""
         require_superuser(current_user)
@@ -97,6 +103,8 @@ class CompanyWithDeletedResource(MethodView):
 class CompanyRestoreResource(MethodView):
     @login_required
     @company_bp.response(200, MessageSchema)
+    @company_bp.response(404, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def post(self, company_id):
         """会社復元"""
         require_superuser(current_user)
@@ -109,6 +117,8 @@ class CompanyRestoreResource(MethodView):
 class CompanyPermanentDeleteResource(MethodView):
     @login_required
     @company_bp.response(200, MessageSchema)
+    @company_bp.response(404, ErrorResponseSchema)
+    @company_bp.response(403, ErrorResponseSchema)
     def delete(self, company_id):
         """会社物理削除"""
         require_superuser(current_user)

--- a/app/routes/objectives_route.py
+++ b/app/routes/objectives_route.py
@@ -2,34 +2,17 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required, current_user
-from marshmallow import Schema, fields
 
 from app.services import objectives_service
-
-class ObjectiveSchema(Schema):
-    id = fields.Int()
-    task_id = fields.Int()
-    title = fields.Str()
-    due_date = fields.Str(allow_none=True)
-    assigned_user_id = fields.Int(allow_none=True)
-    status_id = fields.Int()
-    created_by = fields.Int()
-    created_at = fields.Str()
-
-class ObjectiveInputSchema(Schema):
-    task_id = fields.Int(required=True)
-    title = fields.Str(required=True)
-    due_date = fields.Str(load_default=None)
-    assigned_user_id = fields.Int(load_default=None)
-    status_id = fields.Int(load_default=None)
-
-class MessageSchema(Schema):
-    message = fields.Str()
-    error = fields.Str(load_default=None)
-
-class StatusSchema(Schema):
-    id = fields.Int()
-    label = fields.Str()
+from app.schemas import (
+    ObjectiveSchema,
+    ObjectiveInputSchema,
+    ObjectiveResponseSchema,
+    ObjectivesListSchema,
+    StatusSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 objectives_bp = Blueprint("Objectives", __name__, description="オブジェクティブ管理")
 
@@ -37,7 +20,10 @@ objectives_bp = Blueprint("Objectives", __name__, description="オブジェク�
 class ObjectiveListResource(MethodView):
     @login_required
     @objectives_bp.arguments(ObjectiveInputSchema)
-    @objectives_bp.response(201, MessageSchema)
+    @objectives_bp.response(201, ObjectiveResponseSchema)
+    @objectives_bp.response(400, ErrorResponseSchema)
+    @objectives_bp.response(403, ErrorResponseSchema)
+    @objectives_bp.response(404, ErrorResponseSchema)
     def post(self, data):
         """オブジェクティブ作成"""
         result, status = objectives_service.create_objective(data, current_user)
@@ -47,7 +33,10 @@ class ObjectiveListResource(MethodView):
 class ObjectiveResource(MethodView):
     @login_required
     @objectives_bp.arguments(ObjectiveInputSchema)
-    @objectives_bp.response(200, MessageSchema)
+    @objectives_bp.response(200, ObjectiveResponseSchema)
+    @objectives_bp.response(400, ErrorResponseSchema)
+    @objectives_bp.response(403, ErrorResponseSchema)
+    @objectives_bp.response(404, ErrorResponseSchema)
     def put(self, data, objective_id):
         """オブジェクティブ更新"""
         result, status = objectives_service.update_objective(objective_id, data, current_user)
@@ -55,6 +44,8 @@ class ObjectiveResource(MethodView):
 
     @login_required
     @objectives_bp.response(200, MessageSchema)
+    @objectives_bp.response(403, ErrorResponseSchema)
+    @objectives_bp.response(404, ErrorResponseSchema)
     def delete(self, objective_id):
         """オブジェクティブ削除"""
         result, status = objectives_service.delete_objective(objective_id, current_user)
@@ -62,6 +53,8 @@ class ObjectiveResource(MethodView):
 
     @login_required
     @objectives_bp.response(200, ObjectiveSchema)
+    @objectives_bp.response(403, ErrorResponseSchema)
+    @objectives_bp.response(404, ErrorResponseSchema)
     def get(self, objective_id):
         """オブジェクティブ詳細取得"""
         result, status = objectives_service.get_objective(objective_id, current_user)
@@ -70,7 +63,9 @@ class ObjectiveResource(MethodView):
 @objectives_bp.route('/tasks/<int:task_id>/objectives')
 class TaskObjectivesResource(MethodView):
     @login_required
-    @objectives_bp.response(200, fields.Dict())
+    @objectives_bp.response(200, ObjectivesListSchema)
+    @objectives_bp.response(403, ErrorResponseSchema)
+    @objectives_bp.response(404, ErrorResponseSchema)
     def get(self, task_id):
         """タスクのオブジェクティブ一覧"""
         result, status = objectives_service.get_objectives_for_task(task_id, current_user)

--- a/app/routes/progress_updates_route.py
+++ b/app/routes/progress_updates_route.py
@@ -2,25 +2,14 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required, current_user
-from marshmallow import Schema, fields
 
 from app.services import progress_updates_service
-
-class ProgressInputSchema(Schema):
-    status_id = fields.Int(required=True)
-    detail = fields.Str(required=True)
-    report_date = fields.Str(required=True)
-
-class ProgressSchema(Schema):
-    id = fields.Int()
-    status = fields.Str()
-    detail = fields.Str()
-    report_date = fields.Str()
-    updated_by = fields.Str()
-
-class MessageSchema(Schema):
-    message = fields.Str()
-    error = fields.Str(load_default=None)
+from app.schemas import (
+    ProgressInputSchema,
+    ProgressSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 progress_bp = Blueprint("Progress", __name__, description="進捗更新")
 
@@ -29,6 +18,9 @@ class ProgressListResource(MethodView):
     @login_required
     @progress_bp.arguments(ProgressInputSchema)
     @progress_bp.response(201, MessageSchema)
+    @progress_bp.response(400, ErrorResponseSchema)
+    @progress_bp.response(403, ErrorResponseSchema)
+    @progress_bp.response(404, ErrorResponseSchema)
     def post(self, data, objective_id):
         """進捗追加"""
         result, status = progress_updates_service.add_progress(objective_id, data, current_user)
@@ -36,6 +28,8 @@ class ProgressListResource(MethodView):
 
     @login_required
     @progress_bp.response(200, ProgressSchema(many=True))
+    @progress_bp.response(403, ErrorResponseSchema)
+    @progress_bp.response(404, ErrorResponseSchema)
     def get(self, objective_id):
         """進捗一覧取得"""
         result, status = progress_updates_service.get_progress_list(objective_id, current_user)
@@ -45,6 +39,8 @@ class ProgressListResource(MethodView):
 class LatestProgressResource(MethodView):
     @login_required
     @progress_bp.response(200, ProgressSchema)
+    @progress_bp.response(403, ErrorResponseSchema)
+    @progress_bp.response(404, ErrorResponseSchema)
     def get(self, objective_id):
         """最新進捗取得"""
         result, status = progress_updates_service.get_latest_progress(objective_id, current_user)
@@ -54,6 +50,8 @@ class LatestProgressResource(MethodView):
 class ProgressResource(MethodView):
     @login_required
     @progress_bp.response(200, MessageSchema)
+    @progress_bp.response(403, ErrorResponseSchema)
+    @progress_bp.response(404, ErrorResponseSchema)
     def delete(self, progress_id):
         """進捗削除"""
         result, status = progress_updates_service.delete_progress(progress_id, current_user)

--- a/app/routes/task_core_route.py
+++ b/app/routes/task_core_route.py
@@ -2,35 +2,16 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required, current_user
-from marshmallow import Schema, fields
-
 from app.services import task_core_service
-
-class TaskSchema(Schema):
-    id = fields.Int()
-    status_id = fields.Int(allow_none=True)
-    title = fields.Str()
-    description = fields.Str()
-    due_date = fields.Str(allow_none=True)
-    assigned_user_id = fields.Int(allow_none=True)
-    created_by = fields.Int()
-    created_at = fields.Str()
-    display_order = fields.Int(allow_none=True)
-    organization_id = fields.Int()
-
-class TaskInputSchema(Schema):
-    title = fields.Str(required=True)
-    description = fields.Str(load_default="")
-    due_date = fields.Str(load_default=None)
-    status_id = fields.Int(load_default=None)
-    display_order = fields.Int(load_default=None)
-
-class OrderSchema(Schema):
-    order = fields.List(fields.Int(), required=True)
-
-class MessageSchema(Schema):
-    message = fields.Str()
-    error = fields.Str(load_default=None)
+from app.schemas import (
+    TaskSchema,
+    TaskInputSchema,
+    TaskCreateResponseSchema,
+    TaskListResponseSchema,
+    OrderSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 task_core_bp = Blueprint("Tasks", __name__, url_prefix="/tasks", description="タスク管理")
 
@@ -38,14 +19,16 @@ task_core_bp = Blueprint("Tasks", __name__, url_prefix="/tasks", description="�
 class TaskListResource(MethodView):
     @login_required
     @task_core_bp.arguments(TaskInputSchema)
-    @task_core_bp.response(201, MessageSchema)
+    @task_core_bp.response(201, TaskCreateResponseSchema)
+    @task_core_bp.response(400, ErrorResponseSchema)
     def post(self, data):
         """タスク作成"""
         resp, status = task_core_service.create_task(data, current_user)
         return resp.get_json(), status
 
     @login_required
-    @task_core_bp.response(200, fields.Dict())
+    @task_core_bp.response(200, TaskListResponseSchema)
+    @task_core_bp.response(401, ErrorResponseSchema)
     def get(self):
         """タスク一覧"""
         resp, status = task_core_service.get_tasks(current_user)
@@ -58,6 +41,9 @@ class TaskResource(MethodView):
     @login_required
     @task_core_bp.arguments(TaskInputSchema)
     @task_core_bp.response(200, MessageSchema)
+    @task_core_bp.response(400, ErrorResponseSchema)
+    @task_core_bp.response(403, ErrorResponseSchema)
+    @task_core_bp.response(404, ErrorResponseSchema)
     def put(self, data, task_id):
         """タスク更新"""
         resp, status = task_core_service.update_task(task_id, data, current_user)
@@ -65,6 +51,8 @@ class TaskResource(MethodView):
 
     @login_required
     @task_core_bp.response(200, MessageSchema)
+    @task_core_bp.response(403, ErrorResponseSchema)
+    @task_core_bp.response(404, ErrorResponseSchema)
     def delete(self, task_id):
         """タスク削除"""
         resp, status = task_core_service.delete_task(task_id, current_user)
@@ -75,6 +63,8 @@ class ObjectiveOrderResource(MethodView):
     @login_required
     @task_core_bp.arguments(OrderSchema)
     @task_core_bp.response(200, MessageSchema)
+    @task_core_bp.response(400, ErrorResponseSchema)
+    @task_core_bp.response(404, ErrorResponseSchema)
     def post(self, data, task_id):
         """オブジェクティブ順序更新"""
         resp, status = task_core_service.update_objective_order(task_id, data)

--- a/app/routes/task_export_route.py
+++ b/app/routes/task_export_route.py
@@ -2,13 +2,10 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import send_file, jsonify
 from flask_login import login_required, current_user
-from marshmallow import Schema, fields
 
 from app.services.task_export_service import TaskDataExporter
 from app.models import db
-
-class YAMLResponseSchema(Schema):
-    yaml = fields.Str()
+from app.schemas import YAMLResponseSchema, ErrorResponseSchema
 
 
 task_export_bp = Blueprint("TaskExport", __name__, description="タスクエクスポート")
@@ -31,6 +28,7 @@ class ExportExcelResource(MethodView):
 class ExportYAMLResource(MethodView):
     @login_required
     @task_export_bp.response(200, YAMLResponseSchema)
+    @task_export_bp.response(401, ErrorResponseSchema)
     def get(self):
         """タスクをYAMLでエクスポート"""
         exporter = TaskDataExporter(current_user.id, db)

--- a/app/routes/task_order_route.py
+++ b/app/routes/task_order_route.py
@@ -2,19 +2,14 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required
-from marshmallow import Schema, fields
 
 from app.services import task_order_service
-
-class TaskOrderSchema(Schema):
-    task_id = fields.Int()
-    title = fields.Str()
-
-class TaskOrderInputSchema(Schema):
-    task_ids = fields.List(fields.Int(), required=True)
-
-class MessageSchema(Schema):
-    message = fields.Str()
+from app.schemas import (
+    TaskOrderSchema,
+    TaskOrderInputSchema,
+    MessageSchema,
+    ErrorResponseSchema,
+)
 
 
 task_order_bp = Blueprint("TaskOrder", __name__, url_prefix="/task_order", description="タスク並び順")
@@ -23,6 +18,7 @@ task_order_bp = Blueprint("TaskOrder", __name__, url_prefix="/task_order", descr
 class TaskOrderResource(MethodView):
     @login_required
     @task_order_bp.response(200, TaskOrderSchema(many=True))
+    @task_order_bp.response(404, ErrorResponseSchema)
     def get(self, user_id):
         """タスク並び順取得"""
         resp = task_order_service.get_task_order(user_id)
@@ -31,6 +27,7 @@ class TaskOrderResource(MethodView):
     @login_required
     @task_order_bp.arguments(TaskOrderInputSchema)
     @task_order_bp.response(200, MessageSchema)
+    @task_order_bp.response(400, ErrorResponseSchema)
     def post(self, data, user_id):
         """タスク並び順保存"""
         resp = task_order_service.save_task_order(user_id, data)

--- a/app/routes/test_routes.py
+++ b/app/routes/test_routes.py
@@ -1,9 +1,6 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from marshmallow import Schema, fields
-
-class MessageSchema(Schema):
-    message = fields.Str()
+from app.schemas import MessageSchema
 
 test_bp = Blueprint('Test', __name__, description="テスト用エンドポイント")
 

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,53 @@
+from .common_schemas import MessageSchema, ErrorResponseSchema, YAMLResponseSchema
+from .task_schemas import (
+    TaskSchema,
+    TaskInputSchema,
+    TaskCreateResponseSchema,
+    TaskListResponseSchema,
+    OrderSchema,
+    TaskOrderSchema,
+    TaskOrderInputSchema,
+)
+from .user_schemas import (
+    UserSchema,
+    UserInputSchema,
+    UserCreateResponseSchema,
+    LoginResponseSchema,
+    LoginSchema,
+    WPLoginSchema,
+)
+from .company_schemas import CompanySchema, CompanyInputSchema
+from .organization_schemas import (
+    OrganizationSchema,
+    OrganizationInputSchema,
+    OrganizationUpdateSchema,
+)
+from .objective_schemas import (
+    ObjectiveSchema,
+    ObjectiveInputSchema,
+    ObjectiveResponseSchema,
+    ObjectivesListSchema,
+    StatusSchema,
+)
+from .progress_schemas import ProgressSchema, ProgressInputSchema
+from .access_scope_schemas import AccessScopeSchema, AccessScopeInputSchema
+from .task_access_schemas import (
+    AccessUserSchema,
+    OrgAccessSchema,
+    AccessLevelInputSchema,
+)
+from .ai_schemas import AISuggestInputSchema, JobIdSchema, AIResultSchema
+
+__all__ = [
+    'MessageSchema', 'ErrorResponseSchema', 'YAMLResponseSchema',
+    'TaskSchema', 'TaskInputSchema', 'TaskCreateResponseSchema', 'TaskListResponseSchema',
+    'OrderSchema', 'TaskOrderSchema', 'TaskOrderInputSchema',
+    'UserSchema', 'UserInputSchema', 'UserCreateResponseSchema', 'LoginResponseSchema', 'LoginSchema', 'WPLoginSchema',
+    'CompanySchema', 'CompanyInputSchema',
+    'OrganizationSchema', 'OrganizationInputSchema', 'OrganizationUpdateSchema',
+    'ObjectiveSchema', 'ObjectiveInputSchema', 'ObjectiveResponseSchema', 'ObjectivesListSchema', 'StatusSchema',
+    'ProgressSchema', 'ProgressInputSchema',
+    'AccessScopeSchema', 'AccessScopeInputSchema',
+    'AccessUserSchema', 'OrgAccessSchema', 'AccessLevelInputSchema',
+    'AISuggestInputSchema', 'JobIdSchema', 'AIResultSchema',
+]

--- a/app/schemas/access_scope_schemas.py
+++ b/app/schemas/access_scope_schemas.py
@@ -1,0 +1,10 @@
+from marshmallow import Schema, fields
+
+class AccessScopeSchema(Schema):
+    id = fields.Int()
+    organization_id = fields.Int()
+    role = fields.Str()
+
+class AccessScopeInputSchema(Schema):
+    organization_id = fields.Int(required=True)
+    role = fields.Str(required=True)

--- a/app/schemas/ai_schemas.py
+++ b/app/schemas/ai_schemas.py
@@ -1,0 +1,13 @@
+from marshmallow import Schema, fields
+
+class AISuggestInputSchema(Schema):
+    task_info = fields.Dict(required=True)
+    mode = fields.Str(load_default="task_name")
+
+class JobIdSchema(Schema):
+    job_id = fields.Str()
+
+class AIResultSchema(Schema):
+    job_id = fields.Str()
+    status = fields.Str()
+    message = fields.Str(load_default=None)

--- a/app/schemas/common_schemas.py
+++ b/app/schemas/common_schemas.py
@@ -1,0 +1,10 @@
+from marshmallow import Schema, fields
+
+class MessageSchema(Schema):
+    message = fields.Str()
+
+class ErrorResponseSchema(Schema):
+    error = fields.Str()
+
+class YAMLResponseSchema(Schema):
+    yaml = fields.Str()

--- a/app/schemas/company_schemas.py
+++ b/app/schemas/company_schemas.py
@@ -1,0 +1,8 @@
+from marshmallow import Schema, fields
+
+class CompanySchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+
+class CompanyInputSchema(Schema):
+    name = fields.Str(required=True)

--- a/app/schemas/objective_schemas.py
+++ b/app/schemas/objective_schemas.py
@@ -1,0 +1,29 @@
+from marshmallow import Schema, fields
+
+class ObjectiveSchema(Schema):
+    id = fields.Int()
+    task_id = fields.Int()
+    title = fields.Str()
+    due_date = fields.Str(allow_none=True)
+    assigned_user_id = fields.Int(allow_none=True)
+    status_id = fields.Int()
+    created_by = fields.Int()
+    created_at = fields.Str()
+
+class ObjectiveInputSchema(Schema):
+    task_id = fields.Int(required=True)
+    title = fields.Str(required=True)
+    due_date = fields.Str(load_default=None)
+    assigned_user_id = fields.Int(load_default=None)
+    status_id = fields.Int(load_default=None)
+
+class ObjectiveResponseSchema(Schema):
+    message = fields.Str()
+    objective = fields.Nested(ObjectiveSchema)
+
+class ObjectivesListSchema(Schema):
+    objectives = fields.List(fields.Nested(ObjectiveSchema))
+
+class StatusSchema(Schema):
+    id = fields.Int()
+    label = fields.Str()

--- a/app/schemas/organization_schemas.py
+++ b/app/schemas/organization_schemas.py
@@ -1,0 +1,19 @@
+from marshmallow import Schema, fields
+
+class OrganizationSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+    org_code = fields.Str()
+    company_id = fields.Int()
+    parent_id = fields.Int(allow_none=True)
+    level = fields.Int()
+
+class OrganizationInputSchema(Schema):
+    name = fields.Str(required=True)
+    org_code = fields.Str(required=True)
+    company_id = fields.Int(load_default=None)
+    parent_id = fields.Int(load_default=None)
+
+class OrganizationUpdateSchema(Schema):
+    name = fields.Str()
+    parent_id = fields.Int(allow_none=True)

--- a/app/schemas/progress_schemas.py
+++ b/app/schemas/progress_schemas.py
@@ -1,0 +1,13 @@
+from marshmallow import Schema, fields
+
+class ProgressInputSchema(Schema):
+    status_id = fields.Int(required=True)
+    detail = fields.Str(required=True)
+    report_date = fields.Str(required=True)
+
+class ProgressSchema(Schema):
+    id = fields.Int()
+    status = fields.Str()
+    detail = fields.Str()
+    report_date = fields.Str()
+    updated_by = fields.Str()

--- a/app/schemas/task_access_schemas.py
+++ b/app/schemas/task_access_schemas.py
@@ -1,0 +1,16 @@
+from marshmallow import Schema, fields
+
+class AccessUserSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+    email = fields.Str()
+    access_level = fields.Str()
+
+class OrgAccessSchema(Schema):
+    organization_id = fields.Int()
+    name = fields.Str()
+    access_level = fields.Str()
+
+class AccessLevelInputSchema(Schema):
+    user_access = fields.List(fields.Dict(), required=True)
+    organization_access = fields.List(fields.Dict(), required=True)

--- a/app/schemas/task_schemas.py
+++ b/app/schemas/task_schemas.py
@@ -1,0 +1,37 @@
+from marshmallow import Schema, fields
+
+class TaskSchema(Schema):
+    id = fields.Int()
+    status_id = fields.Int(allow_none=True)
+    title = fields.Str()
+    description = fields.Str()
+    due_date = fields.Str(allow_none=True)
+    assigned_user_id = fields.Int(allow_none=True)
+    created_by = fields.Int()
+    created_at = fields.Str()
+    display_order = fields.Int(allow_none=True)
+    organization_id = fields.Int()
+
+class TaskInputSchema(Schema):
+    title = fields.Str(required=True)
+    description = fields.Str(load_default="")
+    due_date = fields.Str(load_default=None)
+    status_id = fields.Int(load_default=None)
+    display_order = fields.Int(load_default=None)
+
+class TaskCreateResponseSchema(Schema):
+    message = fields.Str()
+    task = fields.Nested(TaskSchema)
+
+class TaskListResponseSchema(Schema):
+    tasks = fields.List(fields.Nested(TaskSchema))
+
+class OrderSchema(Schema):
+    order = fields.List(fields.Int(), required=True)
+
+class TaskOrderSchema(Schema):
+    task_id = fields.Int()
+    title = fields.Str()
+
+class TaskOrderInputSchema(Schema):
+    task_ids = fields.List(fields.Int(), required=True)

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -1,0 +1,33 @@
+from marshmallow import Schema, fields
+
+class UserSchema(Schema):
+    id = fields.Int()
+    wp_user_id = fields.Int(allow_none=True)
+    name = fields.Str()
+    email = fields.Str()
+    is_superuser = fields.Bool()
+    organization_id = fields.Int(allow_none=True)
+    organization_name = fields.Str(allow_none=True)
+
+class UserInputSchema(Schema):
+    wp_user_id = fields.Int(load_default=None)
+    name = fields.Str(required=True)
+    email = fields.Str(required=True)
+    password = fields.Str(load_default=None)
+    role = fields.Str(load_default=None)
+    organization_id = fields.Int(required=True)
+
+class UserCreateResponseSchema(Schema):
+    message = fields.Str()
+    user = fields.Nested(UserSchema)
+
+class LoginResponseSchema(Schema):
+    message = fields.Str()
+    user = fields.Nested(UserSchema)
+
+class LoginSchema(Schema):
+    email = fields.Str(required=True)
+    password = fields.Str(required=True)
+
+class WPLoginSchema(Schema):
+    wp_user_id = fields.Int(required=True)


### PR DESCRIPTION
## Summary
- centralize Marshmallow schemas under `app/schemas`
- update blueprints to import shared schemas
- add response schemas for success cases
- document error responses using `ErrorResponseSchema`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_smorest')*

------
https://chatgpt.com/codex/tasks/task_e_68798e490cc48331b1c6733b6456f86a