### PR TITLE
Refactor routes to use error handlers

### DIFF
--- a/app/routes/access_scope_routes.py
+++ b/app/routes/access_scope_routes.py
@@ -1,7 +1,14 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
+from flask_login import login_required
 from app.services import access_scope_service
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 from app.schemas import (
     AccessScopeSchema,
     AccessScopeInputSchema,
@@ -11,31 +18,74 @@ from app.schemas import (
 
 access_scope_bp = Blueprint("AccessScopes", __name__, description="アクセススコープ管理")
 
+
+@access_scope_bp.errorhandler(ServiceValidationError)
+def access_scope_validation_error(e):
+    abort(400, message=str(e))
+
+
+@access_scope_bp.errorhandler(ServiceAuthenticationError)
+def access_scope_auth_error(e):
+    abort(401, message=str(e))
+
+
+@access_scope_bp.errorhandler(ServicePermissionError)
+def access_scope_permission_error(e):
+    abort(403, message=str(e))
+
+
+@access_scope_bp.errorhandler(ServiceNotFoundError)
+def access_scope_not_found_error(e):
+    abort(404, message=str(e))
+
 @access_scope_bp.route("/users/<int:user_id>/access-scopes")
 class UserAccessScopeResource(MethodView):
+    @login_required
     @access_scope_bp.response(200, AccessScopeSchema(many=True))
-    @access_scope_bp.response(404, ErrorResponseSchema)
+    @access_scope_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, user_id):
         """ユーザーのスコープ一覧"""
-        result, status = access_scope_service.get_user_scopes(user_id)
-        return result, status
+        scopes = access_scope_service.get_user_scopes(user_id)
+        return scopes
 
+    @login_required
     @access_scope_bp.arguments(AccessScopeInputSchema)
     @access_scope_bp.response(201, MessageSchema)
-    @access_scope_bp.response(200, MessageSchema)
-    @access_scope_bp.response(400, ErrorResponseSchema)
-    @access_scope_bp.response(404, ErrorResponseSchema)
+    @access_scope_bp.alt_response(200, {
+        "description": "OK",
+        "schema": MessageSchema,
+        "content_type": "application/json"
+    })
+    @access_scope_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @access_scope_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data, user_id):
         """スコープ追加"""
-        result, status = access_scope_service.add_access_scope_to_user(user_id, data)
-        return result, status
+        message = access_scope_service.add_access_scope_to_user(user_id, data)
+        return message
 
 @access_scope_bp.route("/access-scopes/<int:scope_id>")
 class AccessScopeResource(MethodView):
+    @login_required
     @access_scope_bp.response(200, MessageSchema)
-    @access_scope_bp.response(404, ErrorResponseSchema)
+    @access_scope_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def delete(self, scope_id):
         """スコープ削除"""
-        result, status = access_scope_service.delete_access_scope(scope_id)
-        return result, status
+        message = access_scope_service.delete_access_scope(scope_id)
+        return message
 

--- a/app/routes/ai_route.py
+++ b/app/routes/ai_route.py
@@ -1,6 +1,5 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required
 from app.services import ai_service
 from app.schemas import (
@@ -9,28 +8,63 @@ from app.schemas import (
     AIResultSchema,
     ErrorResponseSchema,
 )
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 ai_bp = Blueprint("AI", __name__, url_prefix="/ai", description="AI 提案")
+
+@ai_bp.errorhandler(ServiceValidationError)
+def ai_validation_error(e):
+    abort(400, message=str(e))
+
+@ai_bp.errorhandler(ServiceAuthenticationError)
+def ai_auth_error(e):
+    abort(401, message=str(e))
+
+@ai_bp.errorhandler(ServicePermissionError)
+def ai_permission_error(e):
+    abort(403, message=str(e))
+
+@ai_bp.errorhandler(ServiceNotFoundError)
+def ai_not_found_error(e):
+    abort(404, message=str(e))
+
 
 @ai_bp.route("/suggest")
 class AISuggestResource(MethodView):
     @login_required
     @ai_bp.arguments(AISuggestInputSchema)
     @ai_bp.response(202, JobIdSchema)
-    @ai_bp.response(400, ErrorResponseSchema)
+    @ai_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """AI提案実行"""
-        result, status = ai_service.enqueue_ai_task(data)
-        return result, status
+        job = ai_service.enqueue_ai_task(data)
+        return job
 
 @ai_bp.route("/result/<job_id>")
 class AIResultResource(MethodView):
     @login_required
     @ai_bp.response(200, AIResultSchema)
-    @ai_bp.response(202, AIResultSchema)
-    @ai_bp.response(500, ErrorResponseSchema)
+    @ai_bp.alt_response(202, {
+        "description": "Accepted",
+        "schema": AIResultSchema,
+        "content_type": "application/json"
+    })
+    @ai_bp.alt_response(500, {
+        "description": "Internal Server Error",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, job_id):
         """AI結果取得"""
-        result, status = ai_service.get_ai_task_result(job_id)
-        return result, status
+        ai_result = ai_service.get_ai_task_result(job_id)
+        return ai_result
 

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -1,6 +1,5 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required
 from app.services import auth_service
 from app.schemas import (
@@ -12,48 +11,95 @@ from app.schemas import (
     MessageSchema,
     ErrorResponseSchema,
 )
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 auth_bp = Blueprint("Auth", __name__, url_prefix="/auth", description="認証")
+
+@auth_bp.errorhandler(ServiceValidationError)
+def auth_validation_error(e):
+    abort(400, message=str(e))
+
+@auth_bp.errorhandler(ServiceAuthenticationError)
+def auth_auth_error(e):
+    abort(401, message=str(e))
+
+@auth_bp.errorhandler(ServicePermissionError)
+def auth_permission_error(e):
+    abort(403, message=str(e))
+
+@auth_bp.errorhandler(ServiceNotFoundError)
+def auth_not_found_error(e):
+    abort(404, message=str(e))
+
 
 @auth_bp.route("/login")
 class LoginResource(MethodView):
     @auth_bp.arguments(LoginSchema)
     @auth_bp.response(200, LoginResponseSchema)
-    @auth_bp.response(400, ErrorResponseSchema)
-    @auth_bp.response(401, ErrorResponseSchema)
+    @auth_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @auth_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """メールでログイン"""
-        result, status = auth_service.login_with_email(data)
-        return result, status
+        user_info = auth_service.login_with_email(data)
+        return user_info
 
 @auth_bp.route("/login/by-id")
 class LoginByIDResource(MethodView):
     @auth_bp.arguments(WPLoginSchema)
     @auth_bp.response(200, LoginResponseSchema)
-    @auth_bp.response(400, ErrorResponseSchema)
-    @auth_bp.response(404, ErrorResponseSchema)
+    @auth_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @auth_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """WP IDでログイン"""
-        result, status = auth_service.login_with_wp_user_id(data)
-        return result, status
+        user_info = auth_service.login_with_wp_user_id(data)
+        return user_info
 
 @auth_bp.route("/logout")
 class LogoutResource(MethodView):
     @login_required
     @auth_bp.response(200, MessageSchema)
-    @auth_bp.response(401, ErrorResponseSchema)
+    @auth_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self):
         """ログアウト"""
-        result, status = auth_service.logout_user_session()
-        return result, status
+        message = auth_service.logout_user_session()
+        return message
 
 @auth_bp.route("/current_user")
 class CurrentUserResource(MethodView):
     @login_required
     @auth_bp.response(200, UserSchema)
-    @auth_bp.response(401, ErrorResponseSchema)
+    @auth_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """現在のユーザー取得"""
-        result, status = auth_service.get_current_user_info()
-        return result, status
+        user = auth_service.get_current_user_info()
+        return user
 

--- a/app/routes/company_routes.py
+++ b/app/routes/company_routes.py
@@ -32,7 +32,7 @@ class CompanyListResource(MethodView):
         """会社一覧取得"""
         require_superuser(current_user)
         companies = company_service.get_all_companies()
-        return [c.to_dict() for c in companies]
+        return companies
 
     @login_required
     @company_bp.arguments(CompanyInputSchema())

--- a/app/routes/objectives_route.py
+++ b/app/routes/objectives_route.py
@@ -1,7 +1,12 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required, current_user
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 from app.services import objectives_service
 from app.schemas import (
@@ -16,60 +21,125 @@ from app.schemas import (
 
 objectives_bp = Blueprint("Objectives", __name__, description="オブジェクティブ管理")
 
+@objectives_bp.errorhandler(ServiceValidationError)
+def objectives_validation_error(e):
+    abort(400, message=str(e))
+
+@objectives_bp.errorhandler(ServiceAuthenticationError)
+def objectives_auth_error(e):
+    abort(401, message=str(e))
+
+@objectives_bp.errorhandler(ServicePermissionError)
+def objectives_permission_error(e):
+    abort(403, message=str(e))
+
+@objectives_bp.errorhandler(ServiceNotFoundError)
+def objectives_not_found_error(e):
+    abort(404, message=str(e))
+
+
 @objectives_bp.route('/objectives')
 class ObjectiveListResource(MethodView):
     @login_required
     @objectives_bp.arguments(ObjectiveInputSchema)
     @objectives_bp.response(201, ObjectiveResponseSchema)
-    @objectives_bp.response(400, ErrorResponseSchema)
-    @objectives_bp.response(403, ErrorResponseSchema)
-    @objectives_bp.response(404, ErrorResponseSchema)
+    @objectives_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """オブジェクティブ作成"""
-        result, status = objectives_service.create_objective(data, current_user)
-        return result, status
+        objective = objectives_service.create_objective(data, current_user)
+        return objective
 
 @objectives_bp.route('/objectives/<int:objective_id>')
 class ObjectiveResource(MethodView):
     @login_required
     @objectives_bp.arguments(ObjectiveInputSchema)
     @objectives_bp.response(200, ObjectiveResponseSchema)
-    @objectives_bp.response(400, ErrorResponseSchema)
-    @objectives_bp.response(403, ErrorResponseSchema)
-    @objectives_bp.response(404, ErrorResponseSchema)
+    @objectives_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def put(self, data, objective_id):
         """オブジェクティブ更新"""
-        result, status = objectives_service.update_objective(objective_id, data, current_user)
-        return result, status
+        objective = objectives_service.update_objective(objective_id, data, current_user)
+        return objective
 
     @login_required
     @objectives_bp.response(200, MessageSchema)
-    @objectives_bp.response(403, ErrorResponseSchema)
-    @objectives_bp.response(404, ErrorResponseSchema)
+    @objectives_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def delete(self, objective_id):
         """オブジェクティブ削除"""
-        result, status = objectives_service.delete_objective(objective_id, current_user)
-        return result, status
+        message = objectives_service.delete_objective(objective_id, current_user)
+        return message
 
     @login_required
     @objectives_bp.response(200, ObjectiveSchema)
-    @objectives_bp.response(403, ErrorResponseSchema)
-    @objectives_bp.response(404, ErrorResponseSchema)
+    @objectives_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, objective_id):
         """オブジェクティブ詳細取得"""
-        result, status = objectives_service.get_objective(objective_id, current_user)
-        return result, status
+        objective = objectives_service.get_objective(objective_id, current_user)
+        return objective
 
 @objectives_bp.route('/tasks/<int:task_id>/objectives')
 class TaskObjectivesResource(MethodView):
     @login_required
     @objectives_bp.response(200, ObjectivesListSchema)
-    @objectives_bp.response(403, ErrorResponseSchema)
-    @objectives_bp.response(404, ErrorResponseSchema)
+    @objectives_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @objectives_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, task_id):
         """タスクのオブジェクティブ一覧"""
-        result, status = objectives_service.get_objectives_for_task(task_id, current_user)
-        return result, status
+        objectives = objectives_service.get_objectives_for_task(task_id, current_user)
+        return objectives
 
 @objectives_bp.route('/statuses')
 class StatusListResource(MethodView):

--- a/app/routes/organization_routes.py
+++ b/app/routes/organization_routes.py
@@ -1,8 +1,14 @@
-from flask_smorest import Blueprint
+from flask_smorest import Blueprint, abort
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required, current_user
 from marshmallow import fields
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 from app.services import organization_service
 from app.schemas import (
     OrganizationSchema,
@@ -13,6 +19,23 @@ from app.schemas import (
 )
 
 organization_bp = Blueprint("Organizations", __name__, url_prefix="/organizations", description="組織管理")
+
+@organization_bp.errorhandler(ServiceValidationError)
+def organization_validation_error(e):
+    abort(400, message=str(e))
+
+@organization_bp.errorhandler(ServiceAuthenticationError)
+def organization_auth_error(e):
+    abort(401, message=str(e))
+
+@organization_bp.errorhandler(ServicePermissionError)
+def organization_permission_error(e):
+    abort(403, message=str(e))
+
+@organization_bp.errorhandler(ServiceNotFoundError)
+def organization_not_found_error(e):
+    abort(404, message=str(e))
+
 
 
 def resolve_company_id(provided_company_id):
@@ -27,7 +50,11 @@ class OrganizationListResource(MethodView):
     @login_required
     @organization_bp.arguments(OrganizationInputSchema)
     @organization_bp.response(201, OrganizationSchema)
-    @organization_bp.response(400, ErrorResponseSchema)
+    @organization_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """組織作成"""
         name = data.get("name")
@@ -35,72 +62,100 @@ class OrganizationListResource(MethodView):
         company_id = data.get("company_id")
         parent_id = data.get("parent_id")
         if not name or not org_code:
-            return {"error": "name と org_code は必須です"}, 400
+            abort(400, message="name と org_code は必須です")
         try:
             resolved_company_id = resolve_company_id(company_id)
             if parent_id is None:
                 if not organization_service.can_create_root_organization(resolved_company_id):
-                    return {"error": "この会社にはすでにルート組織が存在します"}, 400
-            org = organization_service.create_organization(name, org_code, resolved_company_id, parent_id)
-            return org.to_dict(), 201
+                    abort(400, message="この会社にはすでにルート組織が存在します")
+            org = organization_service.create_organization(
+                name, org_code, resolved_company_id, parent_id
+            )
+            return org
         except ValueError as e:
-            return {"error": str(e)}, 400
+            abort(400, message=str(e))
 
     @login_required
     @organization_bp.response(200, OrganizationSchema(many=True))
-    @organization_bp.response(400, ErrorResponseSchema)
+    @organization_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """組織一覧取得"""
         company_id = request.args.get("company_id", type=int)
         try:
             resolved_company_id = resolve_company_id(company_id)
             orgs = organization_service.get_organizations(resolved_company_id)
-            return [org.to_dict() for org in orgs]
+            return orgs
         except ValueError as e:
-            return {"error": str(e)}, 400
+            abort(400, message=str(e))
 
 @organization_bp.route("/<int:org_id>")
 class OrganizationResource(MethodView):
     @login_required
     @organization_bp.response(200, OrganizationSchema)
-    @organization_bp.response(404, ErrorResponseSchema)
+    @organization_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, org_id):
         """組織取得"""
         org = organization_service.get_organization_by_id(org_id)
         if not org:
-            return {"error": "組織が見つかりません"}, 404
-        return org.to_dict()
+            abort(404, message="組織が見つかりません")
+        return org
 
     @login_required
     @organization_bp.arguments(OrganizationUpdateSchema)
     @organization_bp.response(200, OrganizationSchema)
-    @organization_bp.response(400, ErrorResponseSchema)
-    @organization_bp.response(404, ErrorResponseSchema)
+    @organization_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @organization_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def put(self, data, org_id):
         """組織更新"""
         try:
-            org = organization_service.update_organization(org_id, data.get("name"), data.get("parent_id"))
+            org = organization_service.update_organization(
+                org_id, data.get("name"), data.get("parent_id")
+            )
             if not org:
-                return {"error": "組織が見つかりません"}, 404
-            return org.to_dict()
+                abort(404, message="組織が見つかりません")
+            return org
         except ValueError as e:
-            return {"error": str(e)}, 400
+            abort(400, message=str(e))
 
     @login_required
     @organization_bp.response(200, MessageSchema)
-    @organization_bp.response(400, ErrorResponseSchema)
+    @organization_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def delete(self, org_id):
         """組織削除"""
         success, message = organization_service.delete_organization(org_id)
         if not success:
-            return {"error": message}, 400
+            abort(400, message=message)
         return {"message": message}
 
 @organization_bp.route("/tree")
 class OrganizationTreeResource(MethodView):
     @login_required
     @organization_bp.response(200, fields.List(fields.Nested(OrganizationSchema)))
-    @organization_bp.response(400, ErrorResponseSchema)
+    @organization_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """組織ツリー取得"""
         company_id = request.args.get("company_id", type=int)
@@ -109,18 +164,22 @@ class OrganizationTreeResource(MethodView):
             tree = organization_service.get_organization_tree(resolved_company_id)
             return tree
         except ValueError as e:
-            return {"error": str(e)}, 400
+            abort(400, message=str(e))
 
 @organization_bp.route("/children")
 class OrganizationChildrenResource(MethodView):
     @login_required
     @organization_bp.response(200, OrganizationSchema(many=True))
-    @organization_bp.response(400, ErrorResponseSchema)
+    @organization_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """子組織取得"""
         parent_id = request.args.get("parent_id", type=int)
         if parent_id is None:
-            return {"error": "parent_id パラメータが必要です"}, 400
+            abort(400, message="parent_id パラメータが必要です")
         children = organization_service.get_children(parent_id)
-        return [org.to_dict() for org in children]
+        return children
 

--- a/app/routes/progress_updates_route.py
+++ b/app/routes/progress_updates_route.py
@@ -1,7 +1,12 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required, current_user
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 from app.services import progress_updates_service
 from app.schemas import (
@@ -13,47 +18,100 @@ from app.schemas import (
 
 progress_bp = Blueprint("Progress", __name__, description="進捗更新")
 
+@progress_bp.errorhandler(ServiceValidationError)
+def progress_validation_error(e):
+    abort(400, message=str(e))
+
+@progress_bp.errorhandler(ServiceAuthenticationError)
+def progress_auth_error(e):
+    abort(401, message=str(e))
+
+@progress_bp.errorhandler(ServicePermissionError)
+def progress_permission_error(e):
+    abort(403, message=str(e))
+
+@progress_bp.errorhandler(ServiceNotFoundError)
+def progress_not_found_error(e):
+    abort(404, message=str(e))
+
+
 @progress_bp.route("/objectives/<int:objective_id>/progress")
 class ProgressListResource(MethodView):
     @login_required
     @progress_bp.arguments(ProgressInputSchema)
     @progress_bp.response(201, MessageSchema)
-    @progress_bp.response(400, ErrorResponseSchema)
-    @progress_bp.response(403, ErrorResponseSchema)
-    @progress_bp.response(404, ErrorResponseSchema)
+    @progress_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @progress_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @progress_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data, objective_id):
         """進捗追加"""
-        result, status = progress_updates_service.add_progress(objective_id, data, current_user)
-        return result, status
+        message = progress_updates_service.add_progress(objective_id, data, current_user)
+        return message
 
     @login_required
     @progress_bp.response(200, ProgressSchema(many=True))
-    @progress_bp.response(403, ErrorResponseSchema)
-    @progress_bp.response(404, ErrorResponseSchema)
+    @progress_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @progress_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, objective_id):
         """進捗一覧取得"""
-        result, status = progress_updates_service.get_progress_list(objective_id, current_user)
-        return result, status
+        progress_list = progress_updates_service.get_progress_list(objective_id, current_user)
+        return progress_list
 
 @progress_bp.route("/objectives/<int:objective_id>/latest-progress")
 class LatestProgressResource(MethodView):
     @login_required
     @progress_bp.response(200, ProgressSchema)
-    @progress_bp.response(403, ErrorResponseSchema)
-    @progress_bp.response(404, ErrorResponseSchema)
+    @progress_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @progress_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, objective_id):
         """最新進捗取得"""
-        result, status = progress_updates_service.get_latest_progress(objective_id, current_user)
-        return result, status
+        progress = progress_updates_service.get_latest_progress(objective_id, current_user)
+        return progress
 
 @progress_bp.route("/progress/<int:progress_id>")
 class ProgressResource(MethodView):
     @login_required
     @progress_bp.response(200, MessageSchema)
-    @progress_bp.response(403, ErrorResponseSchema)
-    @progress_bp.response(404, ErrorResponseSchema)
+    @progress_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @progress_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def delete(self, progress_id):
         """進捗削除"""
-        result, status = progress_updates_service.delete_progress(progress_id, current_user)
-        return result, status
+        message = progress_updates_service.delete_progress(progress_id, current_user)
+        return message
 

--- a/app/routes/task_access_route.py
+++ b/app/routes/task_access_route.py
@@ -1,7 +1,12 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required, current_user
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 from app.services import task_access_service
 from app.schemas import (
@@ -14,47 +19,87 @@ from app.schemas import (
 
 task_access_bp = Blueprint("TaskAccess", __name__, url_prefix="/tasks/<int:task_id>/scope", description="タスクアクセス")
 
+@task_access_bp.errorhandler(ServiceValidationError)
+def task_access_validation_error(e):
+    abort(400, message=str(e))
+
+@task_access_bp.errorhandler(ServiceAuthenticationError)
+def task_access_auth_error(e):
+    abort(401, message=str(e))
+
+@task_access_bp.errorhandler(ServicePermissionError)
+def task_access_permission_error(e):
+    abort(403, message=str(e))
+
+@task_access_bp.errorhandler(ServiceNotFoundError)
+def task_access_not_found_error(e):
+    abort(404, message=str(e))
+
+
 @task_access_bp.route('/access_levels')
 class AccessLevelResource(MethodView):
     @login_required
     @task_access_bp.arguments(AccessLevelInputSchema)
     @task_access_bp.response(200, MessageSchema)
-    @task_access_bp.response(400, ErrorResponseSchema)
-    @task_access_bp.response(403, ErrorResponseSchema)
-    @task_access_bp.response(404, ErrorResponseSchema)
+    @task_access_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @task_access_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @task_access_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def put(self, data, task_id):
         """アクセスレベル更新"""
         resp = task_access_service.update_access_level(task_id, data, current_user)
-        data, status = resp.get_json(), resp.status_code
-        return data, status
+        return resp
 
 @task_access_bp.route('/users')
 class TaskUsersResource(MethodView):
     @login_required
     @task_access_bp.response(200, AccessUserSchema(many=True))
-    @task_access_bp.response(401, ErrorResponseSchema)
+    @task_access_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, task_id):
         """タスクユーザー取得"""
         resp = task_access_service.get_task_users(task_id)
-        return resp.get_json(), resp.status_code
+        return resp
 
 @task_access_bp.route('/access_users')
 class TaskAccessUsersResource(MethodView):
     @login_required
     @task_access_bp.response(200, AccessUserSchema(many=True))
-    @task_access_bp.response(401, ErrorResponseSchema)
+    @task_access_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, task_id):
         """ユーザーアクセス一覧"""
         resp = task_access_service.get_task_access_users(task_id)
-        return resp.get_json(), resp.status_code
+        return resp
 
 @task_access_bp.route('/access_organizations')
 class TaskAccessOrganizationsResource(MethodView):
     @login_required
     @task_access_bp.response(200, OrgAccessSchema(many=True))
-    @task_access_bp.response(401, ErrorResponseSchema)
+    @task_access_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, task_id):
         """組織アクセス一覧"""
         resp = task_access_service.get_task_access_organizations(task_id)
-        return resp.get_json(), resp.status_code
+        return resp
 

--- a/app/routes/task_core_route.py
+++ b/app/routes/task_core_route.py
@@ -1,7 +1,12 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required, current_user
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 from app.services import task_core_service
 from app.schemas import (
     TaskSchema,
@@ -15,58 +20,109 @@ from app.schemas import (
 
 task_core_bp = Blueprint("Tasks", __name__, url_prefix="/tasks", description="タスク管理")
 
+@task_core_bp.errorhandler(ServiceValidationError)
+def task_core_validation_error(e):
+    abort(400, message=str(e))
+
+@task_core_bp.errorhandler(ServiceAuthenticationError)
+def task_core_auth_error(e):
+    abort(401, message=str(e))
+
+@task_core_bp.errorhandler(ServicePermissionError)
+def task_core_permission_error(e):
+    abort(403, message=str(e))
+
+@task_core_bp.errorhandler(ServiceNotFoundError)
+def task_core_not_found_error(e):
+    abort(404, message=str(e))
+
+
 @task_core_bp.route("")
 class TaskListResource(MethodView):
     @login_required
     @task_core_bp.arguments(TaskInputSchema)
     @task_core_bp.response(201, TaskCreateResponseSchema)
-    @task_core_bp.response(400, ErrorResponseSchema)
+    @task_core_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """タスク作成"""
-        resp, status = task_core_service.create_task(data, current_user)
-        return resp, status
+        resp = task_core_service.create_task(data, current_user)
+        return resp
 
     @login_required
     @task_core_bp.response(200, TaskListResponseSchema)
-    @task_core_bp.response(401, ErrorResponseSchema)
+    @task_core_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """タスク一覧"""
-        resp, status = task_core_service.get_tasks(current_user)
-        if isinstance(resp, dict):
-            return resp, status
-        return resp.get_json(), status
+        resp = task_core_service.get_tasks(current_user)
+        return resp
 
 @task_core_bp.route("/<int:task_id>")
 class TaskResource(MethodView):
     @login_required
     @task_core_bp.arguments(TaskInputSchema)
     @task_core_bp.response(200, MessageSchema)
-    @task_core_bp.response(400, ErrorResponseSchema)
-    @task_core_bp.response(403, ErrorResponseSchema)
-    @task_core_bp.response(404, ErrorResponseSchema)
+    @task_core_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @task_core_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @task_core_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def put(self, data, task_id):
         """タスク更新"""
-        resp, status = task_core_service.update_task(task_id, data, current_user)
-        return resp.get_json(), status
+        resp = task_core_service.update_task(task_id, data, current_user)
+        return resp
 
     @login_required
     @task_core_bp.response(200, MessageSchema)
-    @task_core_bp.response(403, ErrorResponseSchema)
-    @task_core_bp.response(404, ErrorResponseSchema)
+    @task_core_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @task_core_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def delete(self, task_id):
         """タスク削除"""
-        resp, status = task_core_service.delete_task(task_id, current_user)
-        return resp.get_json(), status
+        resp = task_core_service.delete_task(task_id, current_user)
+        return resp
 
 @task_core_bp.route("/<int:task_id>/objectives/order")
 class ObjectiveOrderResource(MethodView):
     @login_required
     @task_core_bp.arguments(OrderSchema)
     @task_core_bp.response(200, MessageSchema)
-    @task_core_bp.response(400, ErrorResponseSchema)
-    @task_core_bp.response(404, ErrorResponseSchema)
+    @task_core_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @task_core_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data, task_id):
         """オブジェクティブ順序更新"""
-        resp, status = task_core_service.update_objective_order(task_id, data)
-        return resp.get_json(), status
+        resp = task_core_service.update_objective_order(task_id, data)
+        return resp
 

--- a/app/routes/task_export_route.py
+++ b/app/routes/task_export_route.py
@@ -1,6 +1,6 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import send_file, jsonify
+from flask import send_file
 from flask_login import login_required, current_user
 
 from app.services.task_export_service import TaskDataExporter
@@ -28,7 +28,11 @@ class ExportExcelResource(MethodView):
 class ExportYAMLResource(MethodView):
     @login_required
     @task_export_bp.response(200, YAMLResponseSchema)
-    @task_export_bp.response(401, ErrorResponseSchema)
+    @task_export_bp.alt_response(401, {
+        "description": "Unauthorized",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """タスクをYAMLでエクスポート"""
         exporter = TaskDataExporter(current_user.id, db)

--- a/app/routes/task_order_route.py
+++ b/app/routes/task_order_route.py
@@ -1,7 +1,12 @@
 from flask_smorest import Blueprint
 from flask.views import MethodView
-from flask import request
 from flask_login import login_required
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 from app.services import task_order_service
 from app.schemas import (
@@ -14,22 +19,47 @@ from app.schemas import (
 
 task_order_bp = Blueprint("TaskOrder", __name__, url_prefix="/task_order", description="タスク並び順")
 
+@task_order_bp.errorhandler(ServiceValidationError)
+def task_order_validation_error(e):
+    abort(400, message=str(e))
+
+@task_order_bp.errorhandler(ServiceAuthenticationError)
+def task_order_auth_error(e):
+    abort(401, message=str(e))
+
+@task_order_bp.errorhandler(ServicePermissionError)
+def task_order_permission_error(e):
+    abort(403, message=str(e))
+
+@task_order_bp.errorhandler(ServiceNotFoundError)
+def task_order_not_found_error(e):
+    abort(404, message=str(e))
+
+
 @task_order_bp.route('/<int:user_id>')
 class TaskOrderResource(MethodView):
     @login_required
     @task_order_bp.response(200, TaskOrderSchema(many=True))
-    @task_order_bp.response(404, ErrorResponseSchema)
+    @task_order_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, user_id):
         """タスク並び順取得"""
         resp = task_order_service.get_task_order(user_id)
-        return resp.get_json(), resp.status_code
+        return resp
 
     @login_required
     @task_order_bp.arguments(TaskOrderInputSchema)
     @task_order_bp.response(200, MessageSchema)
-    @task_order_bp.response(400, ErrorResponseSchema)
+    @task_order_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data, user_id):
         """タスク並び順保存"""
         resp = task_order_service.save_task_order(user_id, data)
-        return resp.get_json(), resp.status_code
+        return resp
 

--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -2,6 +2,12 @@ from flask_smorest import Blueprint
 from flask.views import MethodView
 from flask import request
 from flask_login import login_required, current_user
+from app.service_errors import (
+    ServiceValidationError,
+    ServiceAuthenticationError,
+    ServicePermissionError,
+    ServiceNotFoundError,
+)
 
 from app.services import user_service
 from app.schemas import (
@@ -14,92 +20,167 @@ from app.schemas import (
 
 user_bp = Blueprint("Users", __name__, description="ユーザー管理")
 
+@user_bp.errorhandler(ServiceValidationError)
+def user_validation_error(e):
+    abort(400, message=str(e))
+
+@user_bp.errorhandler(ServiceAuthenticationError)
+def user_auth_error(e):
+    abort(401, message=str(e))
+
+@user_bp.errorhandler(ServicePermissionError)
+def user_permission_error(e):
+    abort(403, message=str(e))
+
+@user_bp.errorhandler(ServiceNotFoundError)
+def user_not_found_error(e):
+    abort(404, message=str(e))
+
+
 @user_bp.route("/users")
 class UsersResource(MethodView):
     @login_required
     @user_bp.arguments(UserInputSchema)
     @user_bp.response(201, UserCreateResponseSchema)
-    @user_bp.response(400, ErrorResponseSchema)
-    @user_bp.response(403, ErrorResponseSchema)
+    @user_bp.alt_response(400, {
+        "description": "Bad Request",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def post(self, data):
         """ユーザー作成"""
-        result, status = user_service.create_user(data, current_user)
-        if isinstance(result, dict) and status:
-            return result, status
+        result = user_service.create_user(data, current_user)
         return result
 
     @login_required
     @user_bp.response(200, UserSchema(many=True))
-    @user_bp.response(403, ErrorResponseSchema)
-    @user_bp.response(404, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """ユーザー一覧取得"""
         user_id = request.args.get("user_id", type=int)
         org_id = request.args.get("organization_id", type=int)
-        result, status = user_service.get_users(user_id, org_id)
-        return result, status
+        result = user_service.get_users(user_id, org_id)
+        return result
 
 @user_bp.route("/users/<int:user_id>")
 class UserResource(MethodView):
     @login_required
     @user_bp.response(200, UserSchema)
-    @user_bp.response(403, ErrorResponseSchema)
-    @user_bp.response(404, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, user_id):
         """ユーザー取得"""
-        result, status = user_service.get_user_by_id(user_id, current_user)
-        return result, status
+        result = user_service.get_user_by_id(user_id, current_user)
+        return result
 
     @login_required
     @user_bp.arguments(UserInputSchema)
     @user_bp.response(200, UserSchema)
-    @user_bp.response(403, ErrorResponseSchema)
-    @user_bp.response(404, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def put(self, data, user_id):
         """ユーザー更新"""
-        result, status = user_service.update_user(user_id, data, current_user)
-        return result, status
+        result = user_service.update_user(user_id, data, current_user)
+        return result
 
     @login_required
     @user_bp.response(200, MessageSchema)
-    @user_bp.response(403, ErrorResponseSchema)
-    @user_bp.response(404, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def delete(self, user_id):
         """ユーザー削除"""
-        result, status = user_service.delete_user(user_id, current_user)
-        return result, status
+        result = user_service.delete_user(user_id, current_user)
+        return result
 
 @user_bp.route("/users/by-email")
 class UserByEmailResource(MethodView):
     @login_required
     @user_bp.response(200, UserSchema)
-    @user_bp.response(403, ErrorResponseSchema)
-    @user_bp.response(404, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """メールアドレスでユーザー取得"""
         email = request.args.get("email")
-        result, status = user_service.get_user_by_email(email, current_user)
-        return result, status
+        result = user_service.get_user_by_email(email, current_user)
+        return result
 
 @user_bp.route("/users/id-lookup")
 class UserByWPIDResource(MethodView):
     @login_required
     @user_bp.response(200, UserSchema)
-    @user_bp.response(403, ErrorResponseSchema)
-    @user_bp.response(404, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
+    @user_bp.alt_response(404, {
+        "description": "Not Found",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self):
         """WordPress IDでユーザー取得"""
         wp_user_id = request.args.get("wp_user_id", type=int)
-        result, status = user_service.get_user_by_wp_user_id(wp_user_id, current_user)
-        return result, status
+        result = user_service.get_user_by_wp_user_id(wp_user_id, current_user)
+        return result
 
 @user_bp.route("/users/by-org-tree/<int:org_id>")
 class UsersByOrgTreeResource(MethodView):
     @login_required
     @user_bp.response(200, UserSchema(many=True))
-    @user_bp.response(403, ErrorResponseSchema)
+    @user_bp.alt_response(403, {
+        "description": "Forbidden",
+        "schema": ErrorResponseSchema,
+        "content_type": "application/json"
+    })
     def get(self, org_id):
         """組織ツリーでユーザー一覧取得"""
-        result, status = user_service.get_users_by_org_tree(org_id, current_user)
-        return result, status
+        result = user_service.get_users_by_org_tree(org_id, current_user)
+        return result
 

--- a/app/service_errors.py
+++ b/app/service_errors.py
@@ -1,0 +1,16 @@
+class ServiceValidationError(ValueError):
+    """Bad request from service layer."""
+    pass
+
+class ServiceAuthenticationError(ValueError):
+    """Authentication failure from service layer."""
+    pass
+
+class ServicePermissionError(ValueError):
+    """Permission failure from service layer."""
+    pass
+
+class ServiceNotFoundError(ValueError):
+    """Resource not found in service layer."""
+    pass
+

--- a/app/utils.py
+++ b/app/utils.py
@@ -185,3 +185,5 @@ def is_valid_status_id(status_id) -> bool:
     except ValueError:
         return False
 
+
+


### PR DESCRIPTION
## Summary
- remove `handle_service_result` helper
- add `Service*Error` classes for service-layer exceptions
- revert schema files to previous simple versions
- register `errorhandler` functions on each blueprint
- update route handlers to return service results directly

## Testing
- `pytest -q` *(fails: 31 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a92026d408331b447f64626954ce3