### PR TITLE
Update route error handlers

### DIFF
--- a/app/routes/access_scope_routes.py
+++ b/app/routes/access_scope_routes.py
@@ -21,22 +21,22 @@ access_scope_bp = Blueprint("AccessScopes", __name__, description="アクセス�
 
 @access_scope_bp.errorhandler(ServiceValidationError)
 def access_scope_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 
 @access_scope_bp.errorhandler(ServiceAuthenticationError)
 def access_scope_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 
 @access_scope_bp.errorhandler(ServicePermissionError)
 def access_scope_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 
 @access_scope_bp.errorhandler(ServiceNotFoundError)
 def access_scope_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 @access_scope_bp.route("/users/<int:user_id>/access-scopes")
 class UserAccessScopeResource(MethodView):

--- a/app/routes/ai_route.py
+++ b/app/routes/ai_route.py
@@ -19,19 +19,19 @@ ai_bp = Blueprint("AI", __name__, url_prefix="/ai", description="AI 提案")
 
 @ai_bp.errorhandler(ServiceValidationError)
 def ai_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @ai_bp.errorhandler(ServiceAuthenticationError)
 def ai_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @ai_bp.errorhandler(ServicePermissionError)
 def ai_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @ai_bp.errorhandler(ServiceNotFoundError)
 def ai_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @ai_bp.route("/suggest")

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -22,19 +22,19 @@ auth_bp = Blueprint("Auth", __name__, url_prefix="/auth", description="認証")
 
 @auth_bp.errorhandler(ServiceValidationError)
 def auth_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @auth_bp.errorhandler(ServiceAuthenticationError)
 def auth_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @auth_bp.errorhandler(ServicePermissionError)
 def auth_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @auth_bp.errorhandler(ServiceNotFoundError)
 def auth_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @auth_bp.route("/login")

--- a/app/routes/objectives_route.py
+++ b/app/routes/objectives_route.py
@@ -23,19 +23,19 @@ objectives_bp = Blueprint("Objectives", __name__, description="オブジェク�
 
 @objectives_bp.errorhandler(ServiceValidationError)
 def objectives_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @objectives_bp.errorhandler(ServiceAuthenticationError)
 def objectives_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @objectives_bp.errorhandler(ServicePermissionError)
 def objectives_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @objectives_bp.errorhandler(ServiceNotFoundError)
 def objectives_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @objectives_bp.route('/objectives')

--- a/app/routes/organization_routes.py
+++ b/app/routes/organization_routes.py
@@ -22,19 +22,19 @@ organization_bp = Blueprint("Organizations", __name__, url_prefix="/organization
 
 @organization_bp.errorhandler(ServiceValidationError)
 def organization_validation_error(e):
-     return {"message": str(e)}, 400
+    return {"message": str(e)}, 400
 
 @organization_bp.errorhandler(ServiceAuthenticationError)
 def organization_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @organization_bp.errorhandler(ServicePermissionError)
 def organization_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @organization_bp.errorhandler(ServiceNotFoundError)
 def organization_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 

--- a/app/routes/progress_updates_route.py
+++ b/app/routes/progress_updates_route.py
@@ -20,19 +20,19 @@ progress_bp = Blueprint("Progress", __name__, description="進捗更新")
 
 @progress_bp.errorhandler(ServiceValidationError)
 def progress_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @progress_bp.errorhandler(ServiceAuthenticationError)
 def progress_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @progress_bp.errorhandler(ServicePermissionError)
 def progress_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @progress_bp.errorhandler(ServiceNotFoundError)
 def progress_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @progress_bp.route("/objectives/<int:objective_id>/progress")

--- a/app/routes/task_access_route.py
+++ b/app/routes/task_access_route.py
@@ -21,19 +21,19 @@ task_access_bp = Blueprint("TaskAccess", __name__, url_prefix="/tasks/<int:task_
 
 @task_access_bp.errorhandler(ServiceValidationError)
 def task_access_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @task_access_bp.errorhandler(ServiceAuthenticationError)
 def task_access_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @task_access_bp.errorhandler(ServicePermissionError)
 def task_access_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @task_access_bp.errorhandler(ServiceNotFoundError)
 def task_access_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @task_access_bp.route('/access_levels')

--- a/app/routes/task_core_route.py
+++ b/app/routes/task_core_route.py
@@ -22,19 +22,19 @@ task_core_bp = Blueprint("Tasks", __name__, url_prefix="/tasks", description="ã‚
 
 @task_core_bp.errorhandler(ServiceValidationError)
 def task_core_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @task_core_bp.errorhandler(ServiceAuthenticationError)
 def task_core_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @task_core_bp.errorhandler(ServicePermissionError)
 def task_core_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @task_core_bp.errorhandler(ServiceNotFoundError)
 def task_core_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @task_core_bp.route("")

--- a/app/routes/task_order_route.py
+++ b/app/routes/task_order_route.py
@@ -21,19 +21,19 @@ task_order_bp = Blueprint("TaskOrder", __name__, url_prefix="/task_order", descr
 
 @task_order_bp.errorhandler(ServiceValidationError)
 def task_order_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @task_order_bp.errorhandler(ServiceAuthenticationError)
 def task_order_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @task_order_bp.errorhandler(ServicePermissionError)
 def task_order_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @task_order_bp.errorhandler(ServiceNotFoundError)
 def task_order_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @task_order_bp.route('/<int:user_id>')

--- a/app/routes/user_routes.py
+++ b/app/routes/user_routes.py
@@ -22,19 +22,19 @@ user_bp = Blueprint("Users", __name__, description="ユーザー管理")
 
 @user_bp.errorhandler(ServiceValidationError)
 def user_validation_error(e):
-    abort(400, message=str(e))
+    return {"message": str(e)}, 400
 
 @user_bp.errorhandler(ServiceAuthenticationError)
 def user_auth_error(e):
-    abort(401, message=str(e))
+    return {"message": str(e)}, 401
 
 @user_bp.errorhandler(ServicePermissionError)
 def user_permission_error(e):
-    abort(403, message=str(e))
+    return {"message": str(e)}, 403
 
 @user_bp.errorhandler(ServiceNotFoundError)
 def user_not_found_error(e):
-    abort(404, message=str(e))
+    return {"message": str(e)}, 404
 
 
 @user_bp.route("/users")


### PR DESCRIPTION
## Summary
- return JSON instead of abort in all blueprint errorhandlers

## Testing
- `pytest -q` *(fails: 24 failed, 46 passed, 46 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ad9e02e308331b7af521457f20ccc