### PR TITLE
Fix tests to use common message checker

### DIFF
--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -1,6 +1,7 @@
 import pytest
+
 from app import db
-from app.models import User, Company, Organization
+from app.models import Company, Organization, User
 from tests.utils import check_response_message
 
 @pytest.fixture

--- a/tests/test_task_core_route.py
+++ b/tests/test_task_core_route.py
@@ -1,9 +1,11 @@
 # tests/test_task_core_route.py
 
+from datetime import date, datetime
+
 import pytest
-from datetime import datetime, date
-from app.models import Task, Objective, Status
+
 from app.constants import StatusEnum
+from app.models import Objective, Status, Task
 from tests.utils import check_response_message
 
 @pytest.fixture(scope="function")

--- a/tests/test_task_order_route.py
+++ b/tests/test_task_order_route.py
@@ -1,5 +1,7 @@
-import pytest
 import uuid
+
+import pytest
+
 from tests.utils import check_response_message
 
 @pytest.fixture(scope="function")

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -1,5 +1,7 @@
+from typing import Any, Dict
+
 import pytest
-from typing import Dict, Any
+
 from tests.utils import check_response_message
 
 # --- Constants ---
@@ -25,14 +27,6 @@ def assert_user_created(response, expected_name: str = None):
         assert user['name'] == expected_name
     return user
 
-def assert_error_response(response, expected_status: int, expected_message: str = None):
-    print("assert_error_response",response.get_json() )
-    """エラーレスポンスの共通アサーション"""
-    assert response.status_code == expected_status
-    error_data = response.get_json()
-    if expected_message:
-        assert expected_message in error_data.get('message', '')
-    return error_data
 
 # --- Fixtures ---
 
@@ -64,7 +58,10 @@ class TestUserCreation:
         client = login_as_user(system_admin['email'], system_admin['password'])
         """必須フィールド不足でユーザー作成失敗"""
         res = client.post('/users', json={'email': 'incomplete@example.com'})
-        assert_error_response(res, 422)
+        assert res.status_code == 422
+        data = res.get_json()
+        for field in ['name', 'password', 'organization_id']:
+            assert check_response_message('Missing data for required field.', data, field)
     
     def test_create_user_duplicate_email(self, login_as_user, system_related_users, root_org):
         system_admin = system_related_users['system_admin']
@@ -198,8 +195,9 @@ class TestUserCreationParameterized:
         del payload[missing_field]
         
         res = client.post('/users', json=payload)
-        error_data = assert_error_response(res, 422)
-        assert missing_field in error_data['errors']['json']
+        assert res.status_code == 422
+        data = res.get_json()
+        assert check_response_message('Missing data for required field.', data, missing_field)
     
     @pytest.mark.parametrize("invalid_email", [
         'invalid-email',
@@ -213,4 +211,5 @@ class TestUserCreationParameterized:
         """無効なメールアドレス形式のテスト"""
         payload = create_user_payload(root_org['id'], email=invalid_email)
         res = client.post('/users', json=payload)
-        assert_error_response(res, 400)
+        assert res.status_code == 400
+        assert check_response_message('無効なメールアドレス形式です', res.get_json())


### PR DESCRIPTION
## Summary
- use `check_response_message` to verify error messages
- clean up imports across tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8d66fcf88331a9dc7ab22c14afd1