### PR TITLE
Update tests for new API URLs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -28,3 +28,4 @@ OPENAPI_URL_PREFIX=/
 OPENAPI_JSON_PATH=openapi.json
 OPENAPI_SWAGGER_UI_PATH=/swagger-ui
 OPENAPI_SWAGGER_UI_URL=http://localhost:5000/swagger-ui
+URL_PREFIX=/progress

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -27,7 +27,7 @@ def wp_user_data2(root_org):
 @pytest.fixture(scope='function')
 def created_wp_user_data2(client, wp_user_data2, superuser,login_as_user):
     login_as_user(superuser['email'], superuser["password"])
-    res = client.post('/users', json=wp_user_data2)
+    res = client.post('/progress/users', json=wp_user_data2)
     assert res.status_code == 201
 
 
@@ -39,7 +39,7 @@ def test_login_with_email_success(client, system_related_users, role):
         "email": user["email"],
         "password": user["password"]
     }
-    response = client.post("/auth/login", json=login_data)
+    response = client.post("/progress/auth/login", json=login_data)
     assert response.status_code == 200
     data = response.get_json()
     assert data["message"] == "ログイン成功"
@@ -52,7 +52,7 @@ def test_login_with_email_invalid_email(client):
         "email": "nonexistent@example.com",
         "password": "anypassword"
     }
-    response = client.post("/auth/login", json=login_data)
+    response = client.post("/progress/auth/login", json=login_data)
     assert response.status_code == 401
     data = response.get_json()
     assert check_response_message("無効",data)
@@ -64,7 +64,7 @@ def test_login_with_email_invalid_password(client, system_related_users):
         "email": user["email"],
         "password": "wrongpassword"
     }
-    response = client.post("/auth/login", json=login_data)
+    response = client.post("/progress/auth/login", json=login_data)
     assert response.status_code == 401
     data = response.get_json()
     assert check_response_message("無効", data)
@@ -73,27 +73,27 @@ def test_login_with_email_invalid_password(client, system_related_users):
 def test_login_with_email_missing_fields(client):
     """必須フィールドが不足している場合のテスト"""
     # emailが不足
-    response = client.post("/auth/login", json={"password": "testpassword"})
+    response = client.post("/progress/auth/login", json={"password": "testpassword"})
     assert response.status_code == 422
     data = response.get_json()
     assert check_response_message('Missing data for required field.', data, 'email')
 
     # passwordが不足
-    response = client.post("/auth/login", json={"email": "test@example.com"})
+    response = client.post("/progress/auth/login", json={"email": "test@example.com"})
     assert response.status_code == 422
     data = response.get_json()
     assert check_response_message("Missing data for required field.", data, 'password')
 
 def test_login_with_wp_user_id_success(client, superuser, login_as_user, wp_user_data):
     login_as_user(superuser['email'], superuser["password"])
-    res = client.post('/users', json=wp_user_data)
+    res = client.post('/progress/users', json=wp_user_data)
     assert res.status_code == 201
 
     """wp_user_idでのログイン成功テスト"""
     login_data = {
         "wp_user_id": wp_user_data["wp_user_id"]
     }
-    response = client.post("/auth/login/by-id", json=login_data)
+    response = client.post("/progress/auth/login/by-id", json=login_data)
     assert response.status_code == 200
     data = response.get_json()
     assert data["message"] == "ログイン成功"
@@ -105,14 +105,14 @@ def test_login_with_wp_user_id_not_found(client):
     login_data = {
         "wp_user_id": 99999
     }
-    response = client.post("/auth/login/by-id", json=login_data)
+    response = client.post("/progress/auth/login/by-id", json=login_data)
     assert response.status_code == 404
     data = response.get_json()
     assert check_response_message("見つかりません", data)
 
 def test_login_with_wp_user_id_missing_field(client):
     """wp_user_idが不足している場合のテスト"""
-    response = client.post("/auth/login/by-id", json={})
+    response = client.post("/progress/auth/login/by-id", json={})
     assert response.status_code == 422
     data = response.get_json()
     assert check_response_message("Missing data for required field.", data, 'wp_user_id')
@@ -126,11 +126,11 @@ def test_get_current_user_authenticated(client, system_related_users, role):
         "email": user["email"],
         "password": user["password"]
     }
-    login_response = client.post("/auth/login", json=login_data)
+    login_response = client.post("/progress/auth/login", json=login_data)
     assert login_response.status_code == 200
 
     # 現在のユーザー情報を取得
-    response = client.get("/auth/current_user")
+    response = client.get("/progress/auth/current_user")
     assert response.status_code == 200
     data = response.get_json()
     assert data["email"] == user["email"]
@@ -141,10 +141,10 @@ def test_get_current_user_authenticated(client, system_related_users, role):
 def test_get_current_user_unauthenticated(client):
     """未認証状態での現在のユーザー情報取得テスト"""
     # 念のためログアウトしてセッションを初期化
-    client.post("/auth/logout")
+    client.post("/progress/auth/logout")
     """未認証状態での現在のユーザー情報取得テスト"""
 
-    response = client.get("/auth/current_user")
+    response = client.get("/progress/auth/current_user")
     assert response.status_code == 401
     data = response.get_json()
     assert check_response_message("ログインが必要です", data)
@@ -158,22 +158,22 @@ def test_logout_authenticated(client, system_related_users, role):
         "email": user["email"],
         "password": user["password"]
     }
-    login_response = client.post("/auth/login", json=login_data)
+    login_response = client.post("/progress/auth/login", json=login_data)
     assert login_response.status_code == 200
 
     # ログアウト
-    response = client.post("/auth/logout")
+    response = client.post("/progress/auth/logout")
     assert response.status_code == 200
     data = response.get_json()
     assert "ログアウト" in data["message"]
 
     # ログアウト後は現在のユーザー情報が取得できない
-    response = client.get("/auth/current_user")
+    response = client.get("/progress/auth/current_user")
     assert response.status_code == 401
 
 def test_logout_unauthenticated(client):
     """未認証状態でのログアウトテスト"""
-    response = client.post("/auth/logout")
+    response = client.post("/progress/auth/logout")
     assert response.status_code == 401
     data = response.get_json()
     assert check_response_message("ログインが必要", data)
@@ -187,21 +187,21 @@ def test_login_logout_flow(client,  system_related_users, role):
         "email": user["email"],
         "password": user["password"]
     }
-    login_response = client.post("/auth/login", json=login_data)
+    login_response = client.post("/progress/auth/login", json=login_data)
     assert login_response.status_code == 200
 
     # 2. 現在のユーザー情報取得
-    current_user_response = client.get("/auth/current_user")
+    current_user_response = client.get("/progress/auth/current_user")
     assert current_user_response.status_code == 200
     user_data = current_user_response.get_json()
     assert user_data["email"] == user["email"]
 
     # 3. ログアウト
-    logout_response = client.post("/auth/logout")
+    logout_response = client.post("/progress/auth/logout")
     assert logout_response.status_code == 200
 
     # 4. ログアウト後は認証が必要なエンドポイントにアクセスできない
-    current_user_response = client.get("/auth/current_user")
+    current_user_response = client.get("/progress/auth/current_user")
     assert current_user_response.status_code == 401
 
 @pytest.mark.parametrize("role", ["member", "org_admin", "system_admin"])
@@ -215,7 +215,7 @@ def test_multiple_login_attempts(client,  system_related_users, role):
     
     # 複数回ログインしても成功する
     for i in range(3):
-        response = client.post("/auth/login", json=login_data)
+        response = client.post("/progress/auth/login", json=login_data)
         assert response.status_code == 200
         data = response.get_json()
         assert data["message"] == "ログイン成功"
@@ -227,11 +227,11 @@ def test_login_with_different_methods(client, created_wp_user_data2, wp_user_dat
     wp_login_data = {
         "wp_user_id": user["wp_user_id"]
     }
-    wp_response = client.post("/auth/login/by-id", json=wp_login_data)
+    wp_response = client.post("/progress/auth/login/by-id", json=wp_login_data)
     assert wp_response.status_code == 200
 
     # ログアウト
-    logout_response = client.post("/auth/logout")
+    logout_response = client.post("/progress/auth/logout")
     assert logout_response.status_code == 200
 
     # 今度はメールアドレスでログイン
@@ -239,5 +239,5 @@ def test_login_with_different_methods(client, created_wp_user_data2, wp_user_dat
         "email": user["email"],
         "password": user["password"]
     }
-    email_response = client.post("/auth/login", json=email_login_data)
+    email_response = client.post("/progress/auth/login", json=email_login_data)
     assert email_response.status_code == 200

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -2,15 +2,15 @@
 
 def test_create_company(client, superuser):
     # スーパーユーザーでログイン
-    res = client.post("/auth/login", json={"email": superuser["email"], "password": superuser["password"]})
+    res = client.post("/progress/auth/login", json={"email": superuser["email"], "password": superuser["password"]})
     assert res.status_code == 200
     payload = {'name': 'TestCompany_test_company'}
-    response = client.post('/companies', json=payload)
+    response = client.post('/progress/companies', json=payload)
     assert response.status_code == 201
     company_data = response.get_json()
     assert company_data['name'] == 'TestCompany_test_company'
 
-    response = client.get('/companies')
+    response = client.get('/progress/companies')
     assert response.status_code == 200
 
 

--- a/tests/test_company_routes.py
+++ b/tests/test_company_routes.py
@@ -7,72 +7,72 @@ def create_company_data():
     return {"name": "Test Company"}
 
 def test_create_company(superuser_login, create_company_data):
-    response = superuser_login.post("/companies", json=create_company_data)
+    response = superuser_login.post("/progress/companies", json=create_company_data)
     assert response.status_code == 201
     assert response.json["name"] == create_company_data["name"]
 
 
 
 def test_list_companies(superuser_login):
-    response = superuser_login.get("/companies")
+    response = superuser_login.get("/progress/companies")
     assert response.status_code == 200
     assert isinstance(response.json, list)
 
 def test_get_company_by_id(superuser_login):
     # 会社作成
-    post_response = superuser_login.post("/companies", json={"name": "by_id"})
+    post_response = superuser_login.post("/progress/companies", json={"name": "by_id"})
     assert post_response.status_code == 201
     company_id = post_response.json["id"]
 
     # 取得
-    get_response = superuser_login.get(f"/companies/{company_id}")
+    get_response = superuser_login.get(f"/progress/companies/{company_id}")
     assert get_response.status_code == 200
     assert get_response.json["id"] == company_id
 
 def test_update_company(superuser_login):
     # 作成
-    post_response = superuser_login.post("/companies", json={"name": "Old Name"})
+    post_response = superuser_login.post("/progress/companies", json={"name": "Old Name"})
     company_id = post_response.json["id"]
 
     # 更新
-    response = superuser_login.put(f"/companies/{company_id}", json={"name": "New Name"})
+    response = superuser_login.put(f"/progress/companies/{company_id}", json={"name": "New Name"})
     assert response.status_code == 200
     assert response.json["name"] == "New Name"
 
 def test_delete_and_restore_company(superuser_login):
     # 作成
-    post_response = superuser_login.post("/companies", json={"name": "Delete Me"})
+    post_response = superuser_login.post("/progress/companies", json={"name": "Delete Me"})
     company_id = post_response.json["id"]
 
     # 論理削除
-    delete_response = superuser_login.delete(f"/companies/{company_id}")
+    delete_response = superuser_login.delete(f"/progress/companies/{company_id}")
     assert delete_response.status_code == 200
 
     # 通常取得で見えない
-    get_response = superuser_login.get(f"/companies/{company_id}")
+    get_response = superuser_login.get(f"/progress/companies/{company_id}")
     assert get_response.status_code == 404
 
     # 削除済も含む取得で確認
-    with_deleted = superuser_login.get(f"/companies/with_deleted/{company_id}")
+    with_deleted = superuser_login.get(f"/progress/companies/with_deleted/{company_id}")
     assert with_deleted.status_code == 200
 
     # 復元
-    restore = superuser_login.post(f"/companies/restore/{company_id}")
+    restore = superuser_login.post(f"/progress/companies/restore/{company_id}")
     assert restore.status_code == 200
 
     # 復元後は通常取得で見える
-    restored_get = superuser_login.get(f"/companies/{company_id}")
+    restored_get = superuser_login.get(f"/progress/companies/{company_id}")
     assert restored_get.status_code == 200
 
 def test_permanent_delete_company(superuser_login):
     # 作成
-    post_response = superuser_login.post("/companies", json={"name": "Permanent Delete"})
+    post_response = superuser_login.post("/progress/companies", json={"name": "Permanent Delete"})
     company_id = post_response.json["id"]
 
     # 物理削除
-    response = superuser_login.delete(f"/companies/permanent/{company_id}")
+    response = superuser_login.delete(f"/progress/companies/permanent/{company_id}")
     assert response.status_code == 200
 
     # with_deleted でも見えない
-    get_response = superuser_login.get(f"/companies/with_deleted/{company_id}")
+    get_response = superuser_login.get(f"/progress/companies/with_deleted/{company_id}")
     assert get_response.status_code == 404

--- a/tests/test_new_user.py
+++ b/tests/test_new_user.py
@@ -1,7 +1,7 @@
 def test_full_user_creation_flow(superuser_login, superuser):
     # ① Company を作成
     company_payload = {'name': 'TestCompanyX'}
-    company_res = superuser_login.post('/companies', json=company_payload)
+    company_res = superuser_login.post('/progress/companies', json=company_payload)
     assert company_res.status_code == 201
     company = company_res.json
     assert company['name'] == 'TestCompanyX'
@@ -14,7 +14,7 @@ def test_full_user_creation_flow(superuser_login, superuser):
         'parent_id': None,
         'level': 1
     }
-    org_res = superuser_login.post('/organizations', json=org_payload)
+    org_res = superuser_login.post('/progress/companies', json=org_payload)
     assert org_res.status_code == 201
     org = org_res.json
     assert org['name'] == 'DevelopmentDept'
@@ -27,7 +27,7 @@ def test_full_user_creation_flow(superuser_login, superuser):
         'password': 'testpass123',
         'organization_id': org['id'],
     }
-    user_res = superuser_login.post('/users', json=user_payload)
+    user_res = superuser_login.post('/progress/users', json=user_payload)
     assert user_res.status_code == 201
     user = user_res.json['user']
     assert user['email'] == 'testuser1@example.com'

--- a/tests/test_objectives_routes.py
+++ b/tests/test_objectives_routes.py
@@ -16,7 +16,7 @@ def task(system_admin_client, test_task_data):
     """エンドポイント経由でテスト用タスクを作成"""
     
     # タスクを作成
-    res = client.post("/tasks", json=test_task_data)
+    res = client.post("/progress/tasks", json=test_task_data)
     assert res.status_code == 201
     
     task_data = res.get_json()['task']
@@ -49,82 +49,84 @@ class TestObjectivesAPI:
     def test_get_objectives_for_task_view(self):
         user = self.users['view']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.get(f"/tasks/{self.task['id']}/objectives")
+        resp = client.get(
+            f"/progressobjectives/tasks/{self.task['id']}"
+        )
         assert resp.status_code == 200
 
     def test_create_objective_full(self):
         user = self.users['full']
         client = self.login_as_user(user['email'], user['password'])
         data = self.make_objective_data()
-        resp = client.post("/objectives", json=data)
+        resp = client.post("/progressobjectives", json=data)
         assert resp.status_code == 201
 
     def test_create_objective_edit(self):
         user = self.users['edit']
         client = self.login_as_user(user['email'], user['password'])
         data = self.make_objective_data()
-        resp = client.post("/objectives", json=data)
+        resp = client.post("/progressobjectives", json=data)
         assert resp.status_code == 201
 
     def test_create_objective_view(self):
         user = self.users['view']
         client = self.login_as_user(user['email'], user['password'])
         data = self.make_objective_data()
-        resp = client.post("/objectives", json=data)
+        resp = client.post("/progressobjectives", json=data)
         assert resp.status_code == 403
 
     def test_update_objective_full(self, created_objective):
         user = self.users['full']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.put(f"/objectives/{created_objective['id']}", json={"title": "updated"})
+        resp = client.put(f"/progressobjectives/{created_objective['id']}", json={"title": "updated"})
         assert resp.status_code == 200
 
     def test_update_objective_edit(self, created_objective):
         user = self.users['edit']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.put(f"/objectives/{created_objective['id']}", json={"title": "updated"})
+        resp = client.put(f"/progressobjectives/{created_objective['id']}", json={"title": "updated"})
         assert resp.status_code == 200
 
     def test_update_objective_view(self, created_objective):
         user = self.users['view']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.put(f"/objectives/{created_objective['id']}", json={"title": "updated"})
+        resp = client.put(f"/progressobjectives/{created_objective['id']}", json={"title": "updated"})
         assert resp.status_code == 403
 
     def test_delete_objective_full(self, created_objective):
         user = self.users['full']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.delete(f"/objectives/{created_objective['id']}")
+        resp = client.delete(f"/progressobjectives/{created_objective['id']}")
         assert resp.status_code == 200
 
     def test_delete_objective_edit(self, created_objective):
         user = self.users['edit']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.delete(f"/objectives/{created_objective['id']}")
+        resp = client.delete(f"/progressobjectives/{created_objective['id']}")
         assert resp.status_code == 200
 
     def test_delete_objective_view(self, created_objective):
         user = self.users['view']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.delete(f"/objectives/{created_objective['id']}")
+        resp = client.delete(f"/progressobjectives/{created_objective['id']}")
         assert resp.status_code == 403
 
     def test_get_objective_detail_view(self, created_objective):
         user = self.users['view']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.get(f"/objectives/{created_objective['id']}")
+        resp = client.get(f"/progressobjectives/{created_objective['id']}")
         assert resp.status_code == 200
 
     def test_get_objective_detail_edit(self, created_objective):
         user = self.users['edit']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.get(f"/objectives/{created_objective['id']}")
+        resp = client.get(f"/progressobjectives/{created_objective['id']}")
         assert resp.status_code == 200
 
     def test_get_objective_detail_full(self, created_objective):
         user = self.users['full']
         client = self.login_as_user(user['email'], user['password'])
-        resp = client.get(f"/objectives/{created_objective['id']}")
+        resp = client.get(f"/progressobjectives/{created_objective['id']}")
         assert resp.status_code == 200
 
 @pytest.fixture
@@ -133,7 +135,7 @@ def created_objective(client, login_as_user, task_access_users, make_objective_d
     user = task_access_users['full']
     client = login_as_user(user['email'], user['password'])
     data = make_objective_data()
-    resp = client.post("/objectives", json=data)
+    resp = client.post("/progressobjectives", json=data)
     assert resp.status_code == 201
     obj_id = resp.get_json()['objective']["id"]
     return {"id": obj_id}

--- a/tests/test_organization_routes.py
+++ b/tests/test_organization_routes.py
@@ -6,7 +6,7 @@ from tests.utils import check_response_message
 def test_create_organization(login_as_user, root_org, system_related_users):
     system_admin = system_related_users['system_admin']
     client = login_as_user(system_admin['email'], system_admin['password'])
-    res = client.post('/organizations', json={
+    res = client.post('/progress/companies', json={
         'name': '営業部',
         'org_code': 'sales',
         'parent_id': root_org['id']
@@ -18,11 +18,11 @@ def test_create_organization(login_as_user, root_org, system_related_users):
 
 def test_create_root_organization_twice(login_as_user, superuser):
     client = login_as_user(superuser['email'], superuser["password"])
-    company_res = client.post("/companies", json={'name':'test_create_root_organization_twice'})
+    company_res = client.post("/progress/companies", json={'name':'test_create_root_organization_twice'})
     assert company_res.status_code == 201
     company_res = company_res.get_json()
     # 最初のルート組織作成
-    res1 = client.post('/organizations', json={
+    res1 = client.post('/progress/companies', json={
         'name': 'root',
         'org_code': 'code',
         'company_id': company_res['id'],
@@ -30,7 +30,7 @@ def test_create_root_organization_twice(login_as_user, superuser):
     assert res1.status_code == 201
 
     # 2つ目はエラー
-    res2 = client.post('/organizations', json={
+    res2 = client.post('/progress/companies', json={
         'name': 'AnotherRoot',
         'org_code': 'root2',
         'company_id': company_res['id']
@@ -41,7 +41,7 @@ def test_create_root_organization_twice(login_as_user, superuser):
 def test_get_organizations(login_as_user, test_company, root_org, system_related_users):
     system_admin = system_related_users['system_admin']
     client = login_as_user(system_admin['email'], system_admin['password'])
-    res = client.get(f'/organizations?company_id={test_company['id']}')
+    res = client.get(f'/progress/companies?company_id={test_company['id']}')
     assert res.status_code == 200
     data = res.get_json()
     assert isinstance(data, list)
@@ -50,14 +50,14 @@ def test_get_organizations(login_as_user, test_company, root_org, system_related
 def test_get_organization_by_id(login_as_user, root_org, system_related_users):
     system_admin = system_related_users['system_admin']
     client = login_as_user(system_admin['email'], system_admin['password'])
-    res = client.get(f'/organizations/{root_org['id']}')
+    res = client.get(f'/progress/companies/{root_org['id']}')
     assert res.status_code == 200
     assert res.get_json()['name'] == root_org['name']
 
 def test_update_organization(login_as_user, root_org, system_related_users):
     system_admin = system_related_users['system_admin']
     client = login_as_user(system_admin['email'], system_admin['password'])
-    res = client.put(f'/organizations/{root_org['id']}', json={
+    res = client.put(f'/progress/companies/{root_org['id']}', json={
         'name': '新しい名前',
         'parent_id': None
     })
@@ -71,7 +71,7 @@ def test_delete_organization_with_children(login_as_user, root_org, system_relat
     company_id = root_org['company_id']
 
     # 1. 子組織を作成
-    res_create_child = client.post('/organizations', json={
+    res_create_child = client.post('/progress/companies', json={
         'name': '子組織',
         'org_code': 'child01',
         'parent_id': parent_id
@@ -81,16 +81,16 @@ def test_delete_organization_with_children(login_as_user, root_org, system_relat
     child_id = child_org['id']
 
     # 2. ルート組織の削除（失敗するはず）
-    res_delete_root = client.delete(f'/organizations/{parent_id}')
+    res_delete_root = client.delete(f'/progress/companies/{parent_id}')
     assert res_delete_root.status_code == 400
     assert check_response_message('削除できません', res_delete_root.get_json())
 
     # 3. 子組織を削除（成功するはず）
-    res_delete_child = client.delete(f'/organizations/{child_id}')
+    res_delete_child = client.delete(f'/progress/companies/{child_id}')
     assert res_delete_child.status_code == 200
 
     # 4. 子組織が削除されたか確認（/children）
-    res_check_children = client.get(f'/organizations/children?parent_id={parent_id}')
+    res_check_children = client.get(f'/progress/companies/children?parent_id={parent_id}')
     assert res_check_children.status_code == 200
     children = res_check_children.get_json()
     assert all(c['id'] != child_id for c in children)
@@ -98,7 +98,7 @@ def test_delete_organization_with_children(login_as_user, root_org, system_relat
 def test_get_organization_tree(login_as_user, root_org, system_related_users):
     system_admin = system_related_users['system_admin']
     client = login_as_user(system_admin['email'], system_admin['password'])
-    res = client.get(f'/organizations/tree?company_id={root_org['company_id']}')
+    res = client.get(f'/progress/companies/tree?company_id={root_org['company_id']}')
     assert res.status_code == 200
     assert isinstance(res.get_json(), list)
 
@@ -114,7 +114,7 @@ def test_get_children(login_as_user, root_org, system_related_users):
     db.session.add(child)
     db.session.commit()
 
-    res = client.get(f'/organizations/children?parent_id={root_org['id']}')
+    res = client.get(f'/progress/companies/children?parent_id={root_org['id']}')
     assert res.status_code == 200
     data = res.get_json()
     assert isinstance(data, list)

--- a/tests/test_progress_updates_route.py
+++ b/tests/test_progress_updates_route.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="function")
 def valid_status_id(client):
-    res = client.get("/statuses")
+    res = client.get("/progressobjectives/statuses")
     assert res.status_code == 200
     return res.get_json()[0]["id"]
 
@@ -11,14 +11,14 @@ def valid_status_id(client):
 @pytest.fixture(scope="function")
 def objective_for_progress(system_admin_client, setup_task_access):
     # create task
-    task_res = system_admin_client.post("/tasks", json={"title": "Progress Task"})
+    task_res = system_admin_client.post("/progress/tasks", json={"title": "Progress Task"})
     assert task_res.status_code == 201
     task = task_res.get_json()["task"]
     # set access rights for view/edit/full/owner users
     setup_task_access(task)
     # create objective under the task
     obj_res = system_admin_client.post(
-        "/objectives", json={"task_id": task["id"], "title": "Progress Objective"}
+        "/progressobjectives", json={"task_id": task["id"], "title": "Progress Objective"}
     )
     assert obj_res.status_code == 201
     objective_id = obj_res.get_json()["objective"]["id"]
@@ -37,9 +37,13 @@ def progress_payload(valid_status_id):
 @pytest.fixture(scope="function")
 def created_progress(system_admin_client, objective_for_progress, progress_payload):
     obj_id = objective_for_progress["objective_id"]
-    res = system_admin_client.post(f"/objectives/{obj_id}/progress", json=progress_payload)
+    res = system_admin_client.post(
+        f"/progress/organizations/objectives/{obj_id}/progress", json=progress_payload
+    )
     assert res.status_code == 201
-    list_res = system_admin_client.get(f"/objectives/{obj_id}/progress")
+    list_res = system_admin_client.get(
+        f"/progress/organizations/objectives/{obj_id}/progress"
+    )
     assert list_res.status_code == 200
     progress_id = list_res.get_json()[-1]["id"]
     return {"id": progress_id, "objective_id": obj_id}
@@ -60,7 +64,7 @@ def test_add_progress_permission(
     user = task_access_users[level]
     client = login_as_user(user["email"], user["password"])
     res = client.post(
-        f"/objectives/{objective_for_progress['objective_id']}/progress",
+        f"/progress/organizations/objectives/{objective_for_progress['objective_id']}/progress",
         json=progress_payload,
     )
     assert res.status_code == expected
@@ -69,7 +73,9 @@ def test_add_progress_permission(
 def test_get_progress_list_view(login_as_user, task_access_users, created_progress):
     user = task_access_users["view"]
     client = login_as_user(user["email"], user["password"])
-    res = client.get(f"/objectives/{created_progress['objective_id']}/progress")
+    res = client.get(
+        f"/progress/organizations/objectives/{created_progress['objective_id']}/progress"
+    )
     assert res.status_code == 200
     assert isinstance(res.get_json(), list)
 
@@ -79,14 +85,14 @@ def test_get_latest_progress(login_as_user, task_access_users, objective_for_pro
     user = task_access_users["full"]
     client = login_as_user(user["email"], user["password"])
     client.post(
-        f"/objectives/{obj_id}/progress",
+        f"/progress/organizations/objectives/{obj_id}/progress",
         json={"status_id": valid_status_id, "detail": "old", "report_date": "2024-01-01"},
     )
     client.post(
-        f"/objectives/{obj_id}/progress",
+        f"/progress/organizations/objectives/{obj_id}/progress",
         json={"status_id": valid_status_id, "detail": "new", "report_date": "2024-02-01"},
     )
-    res = client.get(f"/objectives/{obj_id}/latest-progress")
+    res = client.get(f"/progress/organizations/objectives/{obj_id}/latest-progress")
     assert res.status_code == 200
     assert res.get_json()["detail"] == "new"
 
@@ -105,10 +111,14 @@ def test_delete_progress_permission(
 ):
     user = task_access_users[level]
     client = login_as_user(user["email"], user["password"])
-    res = client.delete(f"/progress/{created_progress['id']}")
+    res = client.delete(
+        f"/progress/organizations/progress/{created_progress['id']}"
+    )
     assert res.status_code == expected
 
 
 def test_delete_progress_not_found(system_admin_client):
-    res = system_admin_client.delete("/progress/99999")
+    res = system_admin_client.delete(
+        "/progress/organizations/progress/99999"
+    )
     assert res.status_code == 404

--- a/tests/test_task_core_route.py
+++ b/tests/test_task_core_route.py
@@ -24,7 +24,7 @@ def created_task(system_admin_client, test_task_data):
     """エンドポイント経由でテスト用タスクを作成"""
     
     # タスクを作成
-    res = client.post("/tasks", json=test_task_data)
+    res = client.post("/progress/tasks", json=test_task_data)
     assert res.status_code == 201
     
     task_data = res.get_json()['task']
@@ -41,7 +41,7 @@ def created_objective(client, created_task):
         "due_date": "2024-12-25"
     }
     
-    res = client.post("/objectives", json=objective_data)
+    res = client.post("/progressobjectives", json=objective_data)
     assert res.status_code == 201
     
     objective_result = res.get_json()
@@ -60,7 +60,7 @@ def multiple_objectives(client, created_task):
             "due_date": "2024-12-25"
         }
         
-        res = client.post("/objectives", json=objective_data)
+        res = client.post("/progressobjectives", json=objective_data)
         assert res.status_code == 201
         
         objective_result = res.get_json()
@@ -77,7 +77,7 @@ class TestTaskCreation:
         """正常なタスク作成"""
        
         # タスク作成
-        res = client.post("/tasks", json=test_task_data)
+        res = client.post("/progress/tasks", json=test_task_data)
         assert res.status_code == 201
         
         data = res.get_json()
@@ -89,7 +89,7 @@ class TestTaskCreation:
         """タイトルなしでタスク作成（エラー）"""
      
         # タイトルなしでタスク作成
-        res = client.post("/tasks", json={"description": "Test"})
+        res = client.post("/progress/tasks", json={"description": "Test"})
         assert res.status_code == 422
         
         data = res.get_json()
@@ -100,7 +100,7 @@ class TestTaskCreation:
         """不正な日付でタスク作成（エラー）"""
        
         # 不正な日付でタスク作成
-        res = client.post("/tasks", json={
+        res = client.post("/progress/tasks", json={
             "title": "Test Task",
             "due_date": "invalid-date"
         })
@@ -111,7 +111,7 @@ class TestTaskCreation:
     
     def test_create_task_without_login(self, client, test_task_data):
         """ログインなしでタスク作成（エラー）"""
-        res = client.post("/tasks", json=test_task_data)
+        res = client.post("/progress/tasks", json=test_task_data)
         assert res.status_code == 401
 
 
@@ -126,7 +126,7 @@ class TestTaskUpdate:
             "due_date": "2025-01-15"
         }
         
-        res = client.put(f"/tasks/{created_task['id']}", json=update_data)
+        res = client.put(f"/progress/tasks/{created_task['id']}", json=update_data)
         assert res.status_code == 200
         data = res.get_json()
         assert "タスクを更新しました" in data['message']
@@ -134,7 +134,7 @@ class TestTaskUpdate:
     def test_update_task_status(self, client, created_task):
         """タスクのステータス更新"""
         # ステータス一覧を取得
-        status_res = client.get("/statuses")
+        status_res = client.get("/progressobjectives/statuses")
         assert status_res.status_code == 200
         statuses = status_res.get_json()
         
@@ -143,7 +143,7 @@ class TestTaskUpdate:
         
         update_data = {"status_id": first_status_id}
         
-        res = client.put(f"/tasks/{created_task['id']}", json=update_data)
+        res = client.put(f"/progress/tasks/{created_task['id']}", json=update_data)
         assert res.status_code == 200
         data = res.get_json()
         assert "タスクを更新しました" in data['message']
@@ -152,7 +152,7 @@ class TestTaskUpdate:
         """不正なステータスIDでタスク更新（エラー）"""
         update_data = {"status_id": 999}  # 存在しないステータスID
         
-        res = client.put(f"/tasks/{created_task['id']}", json=update_data)
+        res = client.put(f"/progress/tasks/{created_task['id']}", json=update_data)
         assert res.status_code == 400
         
         data = res.get_json()
@@ -162,7 +162,7 @@ class TestTaskUpdate:
         """不正な日付でタスク更新（エラー）"""
         update_data = {"due_date": "invalid-date"}
         
-        res = client.put(f"/tasks/{created_task['id']}", json=update_data)
+        res = client.put(f"/progress/tasks/{created_task['id']}", json=update_data)
         assert res.status_code == 400
         
         data = res.get_json()
@@ -172,7 +172,7 @@ class TestTaskUpdate:
         client = system_admin_client
         """存在しないタスクの更新（エラー）"""
        
-        res = client.put("/tasks/999", json={"title": "Updated"})
+        res = client.put("/progress/tasks/999", json={"title": "Updated"})
         assert res.status_code == 404
         
         data = res.get_json()
@@ -184,7 +184,7 @@ class TestTaskDeletion:
     
     def test_delete_task_success(self, client, created_task):
         """正常なタスク削除"""
-        res = client.delete(f"/tasks/{created_task['id']}")
+        res = client.delete(f"/progress/tasks/{created_task['id']}")
         assert res.status_code == 200
         
         data = res.get_json()
@@ -195,7 +195,7 @@ class TestTaskDeletion:
 
         """存在しないタスクの削除（エラー）"""
        
-        res = client.delete("/tasks/999")
+        res = client.delete("/progress/tasks/999")
         assert res.status_code == 404
         data = res.get_json()
         assert check_response_message("タスクが見つかりません", data)
@@ -206,7 +206,7 @@ class TestTaskList:
     
     def test_get_tasks_success(self, client, created_task):
         """正常なタスク一覧取得"""
-        res = client.get("/tasks")
+        res = client.get("/progress/tasks")
         assert res.status_code == 200
         
         data = res.get_json()['tasks']
@@ -219,16 +219,16 @@ class TestTaskList:
     
     def test_get_tasks_without_login(self, client):
         """ログインなしでタスク一覧取得（エラー）"""
-        client.post("/auth/logout")  # ログアウト
+        client.post("/progress/auth/logout")  # ログアウト
         
-        res = client.get("/tasks")
+        res = client.get("/progress/tasks")
         assert res.status_code == 401
     
     def test_get_tasks_empty_list(self, system_admin_client):
         client = system_admin_client
         """タスクがない場合の一覧取得"""
        
-        res = client.get("/tasks")
+        res = client.get("/progress/tasks")
         assert res.status_code == 200
         
         data = res.get_json()['tasks']
@@ -246,7 +246,7 @@ class TestObjectiveOrder:
         objective_ids = [obj['objective']["id"] for obj in multiple_objectives]
         reversed_order = list(reversed(objective_ids))
         
-        res = client.post(f"/tasks/{task_id}/objectives/order", json={
+        res = client.post(f"/progress/tasks/{task_id}/objectives/order", json={
             "order": reversed_order
         })
         assert res.status_code == 200
@@ -259,7 +259,7 @@ class TestObjectiveOrder:
         task_id = multiple_objectives[0]["task_id"]
         
         # orderが文字列（不正）
-        res = client.post(f"/tasks/{task_id}/objectives/order", json={
+        res = client.post(f"/progress/tasks/{task_id}/objectives/order", json={
             "order": "invalid"
         })
         assert res.status_code == 422
@@ -272,7 +272,7 @@ class TestObjectiveOrder:
         task_id = multiple_objectives[0]["task_id"]
         
         # 存在しないオブジェクティブIDを含む
-        res = client.post(f"/tasks/{task_id}/objectives/order", json={
+        res = client.post(f"/progress/tasks/{task_id}/objectives/order", json={
             "order": [999, 1000, 1001]
         })
         assert res.status_code == 404
@@ -282,7 +282,7 @@ class TestObjectiveOrder:
     
     def test_update_objective_order_empty_list(self, client, created_task):
         """空のリストでオブジェクティブ順序更新"""
-        res = client.post(f"/tasks/{created_task['id']}/objectives/order", json={
+        res = client.post(f"/progress/tasks/{created_task['id']}/objectives/order", json={
             "order": []
         })
         assert res.status_code == 400
@@ -290,7 +290,7 @@ class TestObjectiveOrder:
    
     def test_update_objective_order_without_order_field(self, client, created_task):
         """orderフィールドなしでオブジェクティブ順序更新（エラー）"""
-        res = client.post(f"/tasks/{created_task['id']}/objectives/order", json={})
+        res = client.post(f"/progress/tasks/{created_task['id']}/objectives/order", json={})
         assert res.status_code == 422
         
         data = res.get_json()
@@ -311,14 +311,14 @@ class TestIntegration:
             "due_date": "2024-12-31"
         }
         
-        create_res = client.post("/tasks", json=task_data)
+        create_res = client.post("/progress/tasks", json=task_data)
         assert create_res.status_code == 201
         
         created_task = create_res.get_json()['task']
         task_id = created_task["id"]
         
         # 2. タスク一覧で確認
-        list_res = client.get("/tasks")
+        list_res = client.get("/progress/tasks")
         assert list_res.status_code == 200
         
         tasks = list_res.get_json()['tasks']
@@ -327,7 +327,7 @@ class TestIntegration:
         
         # 3. タスク更新
         update_data = {"title": "Updated Integration Task"}
-        update_res = client.put(f"/tasks/{task_id}", json=update_data)
+        update_res = client.put(f"/progress/tasks/{task_id}", json=update_data)
         assert update_res.status_code == 200
         
         # 4. オブジェクティブ作成
@@ -336,24 +336,24 @@ class TestIntegration:
             "title": "Integration Objective"
         }
         
-        obj_res = client.post("/objectives", json=objective_data)
+        obj_res = client.post("/progressobjectives", json=objective_data)
         assert obj_res.status_code == 201
         
         objective = obj_res.get_json()['objective']
         objective_id = objective["id"]
         
         # 5. オブジェクティブ順序更新
-        order_res = client.post(f"/tasks/{task_id}/objectives/order", json={
+        order_res = client.post(f"/progress/tasks/{task_id}/objectives/order", json={
             "order": [objective_id]
         })
         assert order_res.status_code == 200
         
         # 6. タスク削除
-        delete_res = client.delete(f"/tasks/{task_id}")
+        delete_res = client.delete(f"/progress/tasks/{task_id}")
         assert delete_res.status_code == 200
         
         # 7. 削除後の一覧確認
-        final_list_res = client.get("/tasks")
+        final_list_res = client.get("/progress/tasks")
         assert final_list_res.status_code == 200
         
         final_tasks = final_list_res.get_json()['tasks']

--- a/tests/test_task_order_route.py
+++ b/tests/test_task_order_route.py
@@ -14,7 +14,7 @@ def order_user(system_admin_client, root_org):
         "organization_id": root_org["id"],
         "role": "member"
     }
-    res = system_admin_client.post("/users", json=payload)
+    res = system_admin_client.post("/progress/users", json=payload)
     assert res.status_code == 201
     user = res.get_json()["user"]
     user["password"] = "testpass"
@@ -28,7 +28,7 @@ def order_user_client(order_user, login_as_user):
 def order_user_tasks(order_user_client):
     tasks = []
     for i in range(3):
-        res = order_user_client.post("/tasks", json={"title": f"Order Task {i+1}"})
+        res = order_user_client.post("/progress/tasks", json={"title": f"Order Task {i+1}"})
         assert res.status_code == 201
         tasks.append(res.get_json()["task"])
     return tasks
@@ -36,7 +36,7 @@ def order_user_tasks(order_user_client):
 class TestTaskOrderRoutes:
     def test_get_task_order(self, order_user_client, order_user_tasks, order_user):
         user_id = order_user["id"]
-        res = order_user_client.get(f"/task_order/{user_id}")
+        res = order_user_client.get(f"/progress/task_order/{user_id}")
         assert res.status_code == 200
         data = res.get_json()
         assert isinstance(data, list)
@@ -48,28 +48,28 @@ class TestTaskOrderRoutes:
     def test_save_task_order_and_get(self, order_user_client, order_user_tasks, order_user):
         user_id = order_user["id"]
         new_order = [t["id"] for t in order_user_tasks]
-        res = order_user_client.post(f"/task_order/{user_id}", json={"task_ids": new_order})
+        res = order_user_client.post(f"/progress/task_order/{user_id}", json={"task_ids": new_order})
         assert res.status_code == 200
         assert res.get_json()["message"] == "タスクの並び順を保存しました"
-        res = order_user_client.get(f"/task_order/{user_id}")
+        res = order_user_client.get(f"/progress/task_order/{user_id}")
         assert res.status_code == 200
         after_order = [item["task_id"] for item in res.get_json()]
         assert after_order == new_order
 
     def test_save_task_order_invalid(self, order_user_client, order_user):
         user_id = order_user["id"]
-        res = order_user_client.post(f"/task_order/{user_id}", json={"task_ids": "invalid"})
+        res = order_user_client.post(f"/progress/task_order/{user_id}", json={"task_ids": "invalid"})
         assert res.status_code == 422
         assert check_response_message("Not a valid list.", res.get_json(), "task_ids")
 
     def test_task_order_requires_login(self, client, order_user):
-        client.post("/auth/logout")
-        res = client.get(f"/task_order/{order_user['id']}")
+        client.post("/progress/auth/logout")
+        res = client.get(f"/progress/task_order/{order_user['id']}")
         assert res.status_code == 401
 
     def test_save_task_order_post_requires_login(self, client, order_user, order_user_tasks):
-        client.post("/auth/logout")
+        client.post("/progress/auth/logout")
         user_id = order_user["id"]
-        res = client.post(f"/task_order/{user_id}", json={"task_ids": [t["id"] for t in order_user_tasks]})
+        res = client.post(f"/progress/task_order/{user_id}", json={"task_ids": [t["id"] for t in order_user_tasks]})
         assert res.status_code == 401
 


### PR DESCRIPTION
## Summary
- add `URL_PREFIX` to test environment
- adjust all test requests for the `/progress` and `/progressobjectives` API prefixes

## Testing
- `pytest tests/test_new_user.py::test_full_user_creation_flow -q` *(fails: assert 422 == 201)*

------
https://chatgpt.com/codex/tasks/task_e_687df60cbdc8833182a35d84f04e9131