### PR TITLE
Align tests with enum-based parameters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def systemadmin_user(client, root_org, superuser):
         "email": "systemadmin@example.com",
         "password": "adminpass",
         "organization_id": root_org["id"],
-        "role": "system_admin"
+        "role": "SYSTEM_ADMIN"
     })
     assert res.status_code == 201
     return res.get_json()
@@ -125,7 +125,7 @@ def task_access_users(client, systemadmin_user, root_org):
             "email": f"taskuser_{level}@example.com",
             "password": "testpass",
             "organization_id": root_org["id"],
-            "role": "member"  # 組織上の役割はmemberでもOK、タスクアクセスレベルは別テーブルで管理
+            "role": "MEMBER"  # 組織上の役割はmemberでもOK、タスクアクセスレベルは別テーブルで管理
         })
         assert res.status_code == 201
         user_data = res.get_json()
@@ -134,7 +134,7 @@ def task_access_users(client, systemadmin_user, root_org):
         client.post(
             "/progress/tasks/1/access_levels",
             json={
-                "user_access": [{"user_id": user_data['user']["id"], "access_level": level}],
+                "user_access": [{"user_id": user_data['user']["id"], "access_level": level.upper()}],
                 "organization_access": [],
             },
         )
@@ -160,7 +160,7 @@ def system_related_users(client, root_org):
             "email": f"systemuser_{role}@example.com",
             "password": "testpass",
             "organization_id": root_org["id"],
-            "role": role
+            "role": role.upper()
         })
         assert res.status_code == 201
         user_data = res.get_json().get("user", res.get_json())  # userキーがあれば抽出
@@ -205,7 +205,7 @@ def setup_task_access(system_admin_client, task_access_users):
         task_id = task["id"]
 
         user_access = [
-            {"user_id": task_access_users[level]["id"], "access_level": level}
+            {"user_id": task_access_users[level]["id"], "access_level": level.upper()}
             for level in ["view", "edit", "full", "owner"]
         ]
         org_access = []  # 必要に応じて組織アクセスも設定可能

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -10,7 +10,7 @@ def wp_user_data(root_org):
         'name': 'ValidUser',
         'email': 'wp_valid@example.com',
         'password': 'password123',
-        'role': 'member',
+        'role': 'MEMBER',
         'wp_user_id':1234,
         'organization_id':root_org['id']
     }
@@ -20,7 +20,7 @@ def wp_user_data2(root_org):
         'name': 'ValidUser',
         'email': 'valid2@example.com',
         'password': 'password123',
-        'role': 'member',
+        'role': 'MEMBER',
         'wp_user_id':2222,
         'organization_id':root_org['id']
     }

--- a/tests/test_progress_updates_route.py
+++ b/tests/test_progress_updates_route.py
@@ -5,7 +5,7 @@ import pytest
 def valid_status_id(client):
     res = client.get("/progress/tasks/statuses")
     assert res.status_code == 200
-    return res.get_json()[0]["enum"]
+    return res.get_json()[0]["enum"].upper()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_task_access_route.py
+++ b/tests/test_task_access_route.py
@@ -30,7 +30,7 @@ def setup_task_access(system_admin_client, task_access_users, created_task_for_a
     task_id = created_task_for_access['id']
 
     user_access = [
-        {"user_id": task_access_users[level]["id"], "access_level": level}
+        {"user_id": task_access_users[level]["id"], "access_level": level.upper()}
         for level in ["view", "edit", "full", "owner"]
     ]
     org_access = [] # 必要に応じて組織アクセスも設定可能
@@ -55,13 +55,13 @@ def setup_task_access_for_get_levels(system_admin_client, task_access_users):
     task_id = res.get_json()["task"]["id"]
 
     user_access = [
-        {"user_id": task_access_users[level]["id"], "access_level": level}
+        {"user_id": task_access_users[level]["id"], "access_level": level.upper()}
         for level in ["view", "edit", "full", "owner"]
     ]
     org_access = [
-        {"organization_id": task_access_users[level]["organization_id"], "access_level": level}
+        {"organization_id": task_access_users[level]["organization_id"], "access_level": level.upper()}
         for level in ["view", "edit", "full", "owner"]
-    ] 
+    ]
     res = system_admin_client.put(
         f"/progress/tasks/{task_id}/access_levels",
         json={"user_access": user_access, "organization_access": org_access}
@@ -80,7 +80,7 @@ class TestTaskAccessLevelUpdate:
         res = system_admin_client.put(
             f"/progress/tasks/{task_id}/access_levels",
             json={
-                "user_access": [{"user_id": user["id"], "access_level": "full"}],
+                "user_access": [{"user_id": user["id"], "access_level": "FULL"}],
                 "organization_access": []
             }
         )
@@ -179,8 +179,8 @@ class TestTaskAccessList:
             assert "access_level" in item
             # Enumに変換可能な文字列であることを確認
             try:
-                enum_value = TaskAccessLevelEnum(item["access_level"])
-            except ValueError:
+                enum_value = TaskAccessLevelEnum[item["access_level"]]
+            except KeyError:
                 assert False, f"Invalid access_level value: {item['access_level']}"
 
     def test_get_task_access_organizations(self, system_admin_client, setup_task_access_for_get_levels):
@@ -193,6 +193,6 @@ class TestTaskAccessList:
             assert "access_level" in item
             # Enumに変換可能な文字列であることを確認
             try:
-                enum_value = TaskAccessLevelEnum(item["access_level"])
-            except ValueError:
+                enum_value = TaskAccessLevelEnum[item["access_level"]]
+            except KeyError:
                 assert False, f"Invalid access_level value: {item['access_level']}"

--- a/tests/test_task_order_route.py
+++ b/tests/test_task_order_route.py
@@ -12,7 +12,7 @@ def order_user(system_admin_client, root_org):
         "email": email,
         "password": "testpass",
         "organization_id": root_org["id"],
-        "role": "member"
+        "role": "MEMBER"
     }
     res = system_admin_client.post("/progress/users", json=payload)
     assert res.status_code == 201

--- a/tests/test_user_routes.py
+++ b/tests/test_user_routes.py
@@ -9,7 +9,7 @@ VALID_USER_DATA = {
     'name': 'ValidUser',
     'email': 'valid@example.com',
     'password': 'password123',
-    'role': 'member'
+    'role': 'MEMBER'
 }
 
 

--- a/tests/test_user_with_scope.py
+++ b/tests/test_user_with_scope.py
@@ -7,7 +7,7 @@ VALID_USER_DATA = {
     'name': 'ValidUser',
     'email': 'valid@example.com',
     'password': 'password123',
-    'role': 'member'
+    'role': 'MEMBER'
 }
 
 # --- Helper Functions ---
@@ -142,7 +142,7 @@ def test_user_with_scopes_role_enum_values(system_admin_client):
     data = response.get_json()
     
     # 有効なロール値を定義
-    valid_roles = ['system_admin', 'org_admin', 'member']  # OrgRoleEnumの値に合わせて調整
+    valid_roles = ['SYSTEM_ADMIN', 'ORG_ADMIN', 'MEMBER']  # OrgRoleEnumの値に合わせて調整
     
     if len(data) > 0:
         for user in data:


### PR DESCRIPTION
## Summary
- update test fixtures to send enum names for roles, access levels, and statuses
- adjust access level checks to use `TaskAccessLevelEnum[...]`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'marshmallow_enum')*

------
https://chatgpt.com/codex/tasks/task_e_6890156b2c208331b4b7bb4204fd7a4c